### PR TITLE
Enforce separate "comment" permission on Sandstorm.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,22 @@ exports.handleMessageSecurity = function(hook_name, context, callback){
     if(apool.numToAttrib && apool.numToAttrib[0] && apool.numToAttrib[0][0]){
       if(apool.numToAttrib[0][0] === "comment"){
         // Comment change, allow it to override readonly security model!!
+
+        var sandstormPermissions =
+            context.client.request.headers["x-sandstorm-permissions"];
+        if(sandstormPermissions !== undefined){
+          // We're running on Sandstorm (or we're *not* on Sandstorm but for
+          // some reason the client has forged a Sandstorm permissions header).
+          // If the header doesn't indicate commenting is allowed, then do
+          // *not* permit the message through. (Since this strictly reduces
+          // the client's permissions, it's not a problem for this code to
+          // run even when not on Sandstorm.)
+          if(sandstormPermissions.split(",").indexOf("comment") === -1){
+            callback();
+            return;
+          }
+        }
+
         callback(true);
       }else{
         callback();

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -33,6 +33,20 @@ function ep_comments(context){
   if(clientVars.readonly){
     this.padInner.append("<style>.comment-changeTo-approve{display:none;}</style>");
   }
+
+  if(clientVars.sandstormPermissions !== undefined){
+    // It appears this is the Sandstorm version of EtherPad. Check if the user
+    // has permission to comment.
+    if(clientVars.sandstormPermissions.indexOf("comment") === -1){
+      // The user does not have permission to comment. OK, hide the comment
+      // button and the ability to reply to comments.
+      $(document.head).contents().append(
+          "<style>.toolbar ul li.addComment{display:none;}</style>");
+      this.padInner.append(
+          "<style>.comment-reply-input,.reply-suggestion," +
+                 ".reply-comment-suggest{display:none;}</style>");
+    }
+  }
 }
 
 // Init Etherpad plugin comment pads


### PR DESCRIPTION
I used to work on Google Docs sharing. One thing I helped implement there was the ability to grant "comment" permission independently of "read" and "write". Originally we only let editors comment, but users made it very clear that they wanted to grant comment permission without write permission. On the other hand, giving comment permission to all readers (as ep_comments currently does) is also not great, because it means public documents end up littered with spam.

Overhauling Etherpad's basic sharing model to include "comment-only" links (separate from the existing read-only links) would probably be a big project. I have not done that here.

However, on Sandstorm, the sharing model is controlled by the platform. The app merely declares what permissions exist, and then Sandstorm provides the UI for users to share various permissions. So, on Sandstorm, we can trivially add a "comment" permission, and I have done so.

This change extends ep_comments with the minimal changes needed to enforce the Sandstorm comment-only permission. I could maintain this as a fork, but the change should be harmless to merge upstream, and this would be a lot easier for me to maintain.
