### PR TITLE
Don't double the number of reply listeners every time there is a reply.

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -979,7 +979,6 @@ ep_comments.prototype.commentRepliesListen = function(){
         // console.log("collecting comment replies");
         self.commentReplies = replies;
         self.collectCommentReplies();
-        self.commentRepliesListen();
       }
     });
   });


### PR DESCRIPTION
I don't actually understand the code here, but I observed that with each new reply on a document, the client was doubling the number of "getCommentReplies" requests it was sending to the server. After a small number of replies, Etherpad would become unresponsive.

Removing this line seems to fix the problem without breaking anything.