### PR TITLE
Listen for replies even if no replies exist at startup.

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -79,8 +79,8 @@ ep_comments.prototype.init = function(){
       // console.log("collecting comment replies");
       self.commentReplies = replies;
       self.collectCommentReplies();
-      self.commentRepliesListen();
     }
+    self.commentRepliesListen();
   });
 
   // Init add push event


### PR DESCRIPTION
AFAICT, if there are no comment replies at the time the pad is loaded, then the code never sets up to listen for future replies, so the user can't see them. This change seems to fix the problem.