### PR TITLE
Fix bug of not keeping the content of cut on buffer

### DIFF
--- a/static/js/copyPasteEvents.js
+++ b/static/js/copyPasteEvents.js
@@ -1,4 +1,4 @@
-exports.addTextOnClipboardAndRemoveSelectionIfNecessary = function(e, ace, padInner){
+exports.addTextOnClipboard = function(e, ace, padInner, removeSelection){
   var commentIdOnSelection;
   ace.callWithAce(function(ace) {
     commentIdOnSelection = ace.ace_getCommentIdOnSelection();
@@ -20,7 +20,7 @@ exports.addTextOnClipboardAndRemoveSelectionIfNecessary = function(e, ace, padIn
     e.preventDefault();
 
     // if it is a cut event we have to remove the selection
-    if(e.type === "cut"){
+    if(removeSelection){
       padInner.contents()[0].execCommand("delete");
     }
   }

--- a/static/js/copyPasteEvents.js
+++ b/static/js/copyPasteEvents.js
@@ -1,4 +1,4 @@
-exports.addTextOnClipboard = function(e, ace, padInner){
+exports.addTextOnClipboardAndRemoveSelectionIfNecessary = function(e, ace, padInner){
   var commentIdOnSelection;
   ace.callWithAce(function(ace) {
     commentIdOnSelection = ace.ace_getCommentIdOnSelection();
@@ -18,6 +18,11 @@ exports.addTextOnClipboard = function(e, ace, padInner){
     // here we override the default copy behavior
     e.originalEvent.clipboardData.setData('text/html', html);
     e.preventDefault();
+
+    // if it is a cut event we have to remove the selection
+    if(e.type === "cut"){
+      padInner.contents()[0].execCommand("delete");
+    }
   }
 };
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -315,11 +315,11 @@ ep_comments.prototype.init = function(){
   // text<comment><span>to be copied</span></comment>
   if(browser.chrome){
     self.padInner.contents().on("copy", function(e) {
-      events.addTextOnClipboardAndRemoveSelectionIfNecessary(e, self.ace, self.padInner);
+      events.addTextOnClipboard(e, self.ace, self.padInner, false);
     });
 
     self.padInner.contents().on("cut", function(e) {
-      events.addTextOnClipboardAndRemoveSelectionIfNecessary(e, self.ace, self.padInner);
+      events.addTextOnClipboard(e, self.ace, self.padInner, true);
     });
 
     self.padInner.contents().on("paste", function(e) {

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -315,13 +315,11 @@ ep_comments.prototype.init = function(){
   // text<comment><span>to be copied</span></comment>
   if(browser.chrome){
     self.padInner.contents().on("copy", function(e) {
-      events.addTextOnClipboard(e, self.ace, self.padInner);
+      events.addTextOnClipboardAndRemoveSelectionIfNecessary(e, self.ace, self.padInner);
     });
 
     self.padInner.contents().on("cut", function(e) {
-      events.addTextOnClipboard(e, self.ace, self.padInner);
-      // remove the selected text
-      self.padInner.contents()[0].execCommand("delete");
+      events.addTextOnClipboardAndRemoveSelectionIfNecessary(e, self.ace, self.padInner);
     });
 
     self.padInner.contents().on("paste", function(e) {


### PR DESCRIPTION
With this commit we only remove the selection when the cut event is prevented. This way, if it is not prevented the browser makes all the processing ( it adds selection to the clipboard and removes the selection on cut).