### PR TITLE
Fix exception thrown from addTextOnClipboard by requiring underscore.js explicitly.

### DIFF
--- a/static/js/copyPasteEvents.js
+++ b/static/js/copyPasteEvents.js
@@ -1,3 +1,5 @@
+var _ = require("ep_etherpad-lite/static/js/underscore");
+
 exports.addTextOnClipboard = function(e, ace, padInner, removeSelection){
   var commentIdOnSelection;
   ace.callWithAce(function(ace) {


### PR DESCRIPTION
For some reason, with the set of plugins I have going, _ seems to be bound to the i18n function in this context unless I add this.