### PR TITLE
paste a comment from another pad

### DIFF
--- a/commentManager.js
+++ b/commentManager.js
@@ -56,8 +56,8 @@ exports.bulkAddComments = function(padId, data, callback)
 
     var newComments = [];
     var commentIds = _.map(data, function(commentData) {
-      //create the new comment
-      var commentId = "c-" + randomString(16);
+      //if it's the comment was copied it already have a commentID so we don't need create one
+      var commentId = commentData.commentId || "c-" + randomString(16) ;
 
       var comment = {
         "author": commentData.author || "empty",
@@ -67,7 +67,6 @@ exports.bulkAddComments = function(padId, data, callback)
         "changeFrom": commentData.changeFrom,
         "timestamp": parseInt(commentData.timestamp) || new Date().getTime()
       };
-
       //add the entry for this pad
       comments[commentId] = comment;
 

--- a/commentManager.js
+++ b/commentManager.js
@@ -3,6 +3,7 @@ var db = require('ep_etherpad-lite/node/db/DB').db;
 var ERR = require("ep_etherpad-lite/node_modules/async-stacktrace");
 var randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
 var readOnlyManager = require("ep_etherpad-lite/node/db/ReadOnlyManager.js");
+var shared = require('./static/js/shared');
 
 exports.getComments = function (padId, callback)
 {
@@ -56,8 +57,8 @@ exports.bulkAddComments = function(padId, data, callback)
 
     var newComments = [];
     var commentIds = _.map(data, function(commentData) {
-      //if it's the comment was copied it already have a commentID so we don't need create one
-      var commentId = commentData.commentId || "c-" + randomString(16) ;
+      //if the comment was copied it already has a commentID, so we don't need create one
+      var commentId = commentData.commentId || shared.generateCommentId();
 
       var comment = {
         "author": commentData.author || "empty",

--- a/index.js
+++ b/index.js
@@ -79,6 +79,14 @@ exports.socketio = function (hook_name, args, cb){
       });
     });
 
+    socket.on('bulkAddComment', function (padId, data, callback) {
+      commentManager.bulkAddComments(padId, data, function(error, commentsId, comments){
+        socket.broadcast.to(padId).emit('pushAddCommentInBulk');
+        var commentWithCommentId = _.object(commentsId, comments); // {c-123:data, c-124:data}
+        callback(commentWithCommentId)
+      });
+    });
+
     socket.on('bulkAddCommentReplies', function(padId, data, callback){
       commentManager.bulkAddCommentReplies(padId, data, function (err, repliesId, replies){
         socket.broadcast.to(padId).emit('pushAddCommentReply', repliesId, replies);

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var clientIO = require('socket.io-client');
 var commentManager = require('./commentManager');
 var comments = require('./comments');
 var apiUtils = require('./apiUtils');
+var _ = require('ep_etherpad-lite/static/js/underscore');
 
 exports.handleMessageSecurity = function(hook_name, context, callback){
   if(context.message && context.message.data && context.message.data.apool){
@@ -75,6 +76,14 @@ exports.socketio = function (hook_name, args, cb){
       var padId = data.padId;
       commentManager.changeAcceptedState(padId, data.commentId, true, function(){
         socket.broadcast.to(padId).emit('changeAccepted', data.commentId);
+      });
+    });
+
+    socket.on('bulkAddCommentReplies', function(padId, data, callback){
+      commentManager.bulkAddCommentReplies(padId, data, function (err, repliesId, replies){
+        socket.broadcast.to(padId).emit('pushAddCommentReply', repliesId, replies);
+        var repliesWithReplyId = _.zip(repliesId, replies);
+        callback(repliesWithReplyId);
       });
     });
 

--- a/static/css/comment.css
+++ b/static/css/comment.css
@@ -3,10 +3,11 @@ note{
 }
 
 .comment {
-  /*WARNING: if you change this value, you need to change it too on copyPasteEvents.js, otherwise you'll break part of the copy/paste behavior"*/
+  /*WARNING - if you change this value, you need to change it too on copyPasteEvents.js, otherwise you'll break part of the copy/paste behavior"*/
   background: #FFFACD !important;
   border-radius: 0px;
 }
+
 
 .pre-selected-comment {
   background: #FFE168 !important;

--- a/static/js/commentIcons.js
+++ b/static/js/commentIcons.js
@@ -17,22 +17,19 @@ var screenHasSpaceForIcons = function() {
 
 var calculateIfScreenHasSpaceForIcons = function() {
   var $firstElementOnPad = getPadInner().find("#innerdocbody > div").first();
-  var firstElementOnPadLeftEdge = getElementRightEdge($firstElementOnPad);
+  var availableSpaceOnTheRightOfPadLines = getSpaceAvailableOnTheRightSide($firstElementOnPad);
 
-  screenHasSpaceToDisplayIcons = firstElementOnPadLeftEdge !== 0;
+  screenHasSpaceToDisplayIcons = availableSpaceOnTheRightOfPadLines !== 0;
 }
 
-// In the default page view plugin, we define if it has space to show the comment icon
-// when the line(div) has padding-left different from 0. As it's possible to use another
-// plugin to handle pages and this one can be apply instead of padding, border or margin
-// we extend to check all the right edge of the element.
-var getElementRightEdge = function($element) {
+// The space available can be anything like padding, margin or border
+var getSpaceAvailableOnTheRightSide = function($element) {
   var rightPadding      = parseInt($element.css("padding-right"), 10);
   var rightBorder       = parseInt($element.css("border-right-width"), 10);
   var rightMargin       = parseInt($element.css("margin-right"), 10);
 
-  var elementRightEdge = rightPadding + rightBorder + rightMargin;
-  return elementRightEdge;
+  var rightEdgeSpace = rightPadding + rightBorder + rightMargin;
+  return rightEdgeSpace;
 }
 
 // Easier access to outer pad

--- a/static/js/commentIcons.js
+++ b/static/js/commentIcons.js
@@ -16,10 +16,23 @@ var screenHasSpaceForIcons = function() {
 }
 
 var calculateIfScreenHasSpaceForIcons = function() {
-  var firstElementOnPad = getPadInner().find("#innerdocbody > div").first();
-  var rightMargin       = firstElementOnPad.css("margin-right");
+  var $firstElementOnPad = getPadInner().find("#innerdocbody > div").first();
+  var firstElementOnPadLeftEdge = getElementRightEdge($firstElementOnPad);
 
-  screenHasSpaceToDisplayIcons = rightMargin !== "0px";
+  screenHasSpaceToDisplayIcons = firstElementOnPadLeftEdge !== 0;
+}
+
+// In the default page view plugin, we define if it has space to show the comment icon
+// when the line(div) has padding-left different from 0. As it's possible to use another
+// plugin to handle pages and this one can be apply instead of padding, border or margin
+// we extend to check all the right edge of the element.
+var getElementRightEdge = function($element) {
+  var rightPadding      = parseInt($element.css("padding-right"), 10);
+  var rightBorder       = parseInt($element.css("border-right-width"), 10);
+  var rightMargin       = parseInt($element.css("margin-right"), 10);
+
+  var elementRightEdge = rightPadding + rightBorder + rightMargin;
+  return elementRightEdge;
 }
 
 // Easier access to outer pad

--- a/static/js/copyPasteEvents.js
+++ b/static/js/copyPasteEvents.js
@@ -1,24 +1,38 @@
-var _ = require("ep_etherpad-lite/static/js/underscore");
+var randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
+var _ = require('ep_etherpad-lite/static/js/underscore');
 
-exports.addTextOnClipboard = function(e, ace, padInner, removeSelection){
+exports.addTextOnClipboard = function(e, ace, padInner, removeSelection, comments, replies){
   var commentIdOnSelection;
+  var hasCommentOnSelection;
   ace.callWithAce(function(ace) {
     commentIdOnSelection = ace.ace_getCommentIdOnSelection();
+    hasCommentOnSelection = ace.ace_hasCommentOnSelection();
   });
-  // we check if all the selection is in the same comment, if so, we override the copy behavior
-  if (commentIdOnSelection) {
+
+  if(hasCommentOnSelection){
+    var commentsData;
     var range = padInner.contents()[0].getSelection().getRangeAt(0);
-    var hiddenDiv = createHiddenDiv(range);
-    var html = getHtml(hiddenDiv);
-    // when the range selection is fully inside a tag, 'html' will have no HTML tag, so we have to
+    var rawHtml = createHiddenDiv(range);
+    var html = rawHtml;
+    var onlyTextIsSelected = selectionHasOnlyText(rawHtml);
+    // when the range selection is fully inside a tag, 'rawHtml' will have no HTML tag, so we have to
     // build it. Ex: if we have '<span>ab<b>cdef</b>gh</span>" and user selects 'de', the value of
-    //'html' will be 'de', not '<b>de</b>'
-    if (selectionHasOnlyText(html, hiddenDiv)) {
-      html = buildHtmlToCopy(html, range);
-      e.originalEvent.clipboardData.setData('text/copyCommentId', commentIdOnSelection);
+    //'rawHtml' will be 'de', not '<b>de</b>'. As it is not possible to have two comments in the same text
+    // commentIdOnSelection is the commentId in this partial selection
+    if (onlyTextIsSelected) {
+      var textSelected = rawHtml[0].outerText;
+      html = buildHtmlToCopy(textSelected, range, commentIdOnSelection);
     }
+    var commentIds = getCommentIds(html);
+    commentsData = buildCommentsData(html, comments);
+    var htmlToCopy = replaceCommentIdsWithFakeIds(commentsData, html)
+    commentsData = JSON.stringify(commentsData);
+    var replyData = getReplyData(replies, commentIds);
+    replyData = JSON.stringify(replyData);
+    e.originalEvent.clipboardData.setData('text/objectReply', replyData);
+    e.originalEvent.clipboardData.setData('text/objectComment', commentsData);
     // here we override the default copy behavior
-    e.originalEvent.clipboardData.setData('text/html', html);
+    e.originalEvent.clipboardData.setData('text/html', htmlToCopy);
     e.preventDefault();
 
     // if it is a cut event we have to remove the selection
@@ -27,6 +41,77 @@ exports.addTextOnClipboard = function(e, ace, padInner, removeSelection){
     }
   }
 };
+
+var getReplyData = function(replies, commentIds){
+  var replyData = {};
+  _.each(commentIds, function(commentId){
+    replyData =  _.extend(getRepliesFromCommentId(replies, commentId), replyData);
+  });
+  return replyData;
+};
+
+var getRepliesFromCommentId = function(replies, commentId){
+  var repliesFromCommentID = {};
+  _.each(replies, function(reply, replyId){
+    if(reply.commentId === commentId){
+      repliesFromCommentID[replyId] = reply;
+    }
+  });
+  return repliesFromCommentID;
+};
+
+var mapCommentIdToFakeId = function(commentsData){
+  var commmentsDataInverted = {};
+  _.each(commentsData, function(comment, fakeCommentId){
+    var commentId = comment.data.originalCommentId;
+    commmentsDataInverted[commentId] = fakeCommentId;
+  });
+  return commmentsDataInverted;
+};
+
+var replaceCommentIdsWithFakeIds = function(commentsData, html){
+  var commmentsDataInverted =  mapCommentIdToFakeId(commentsData);
+  _.each(commmentsDataInverted, function(fakeCommentId, commentId){
+    $(html).find("." + commentId).removeClass(commentId).addClass(fakeCommentId);
+  });
+  var htmlWithFakeCommentIds = getHtml(html);
+  return htmlWithFakeCommentIds;
+};
+
+var buildCommentsData = function(html, comments){
+  var commentsData = {};
+  var originalCommentIds = getCommentIds(html);
+  if(originalCommentIds.length){
+    _.each(originalCommentIds, function(originalCommentId){
+      var fakeCommentId = generateFakeCommentId();
+      var comment = comments[originalCommentId];
+      comment.data.originalCommentId = originalCommentId;
+      commentsData[fakeCommentId] = comment;
+    });
+  }
+  return commentsData;
+};
+
+var generateFakeCommentId = function(){
+  var commentId = "fakecomment-" + randomString(16);
+  return commentId;
+};
+
+var getCommentIds = function(html){
+  var commentId = null;
+  var allSpans = $(html).find("span");
+  var commentIds = [];
+  _.each(allSpans, function(span){
+    var cls = $(span).attr('class');
+    var classCommentId = /(?:^| )(c-[A-Za-z0-9]*)/.exec(cls);
+    commentId = (classCommentId) ? classCommentId[1] : false;
+    if(commentId){
+      commentIds.push(commentId);
+    }
+  });
+  var uniqueCommentIds = _.uniq(commentIds);
+  return uniqueCommentIds;
+ };
 
 var createHiddenDiv = function(range){
   var content = range.cloneContents();
@@ -39,13 +124,14 @@ var getHtml = function(hiddenDiv){
   return $(hiddenDiv).html();
 };
 
-var selectionHasOnlyText = function(html, hiddenDiv){
+var selectionHasOnlyText = function(rawHtml){
+  var html = getHtml(rawHtml);
   var htmlDecoded = htmlDecode(html);
-  var text = $(hiddenDiv).text();
+  var text = $(rawHtml).text();
   return htmlDecoded === text;
 };
 
-var buildHtmlToCopy = function(html, range) {
+var buildHtmlToCopy = function(html, range, commentId) {
   var htmlOfParentNode = range.commonAncestorContainer.parentNode;
   var tags = getTagsInSelection(htmlOfParentNode);
   // this case happens when we got a selection with one or more styling (bold, italic, underline, strikethrough)
@@ -53,10 +139,9 @@ var buildHtmlToCopy = function(html, range) {
   if(tags){
     html = buildOpenTags(tags) + html + buildCloseTags(tags);
   }
-  var htmlToCopy = "<span class='comment'>" + html + "</span>";
+  var htmlToCopy = $.parseHTML("<div><span class='comment " + commentId + "'>" + html + "</span></br></div>");
   return htmlToCopy;
 };
-
 
 var buildOpenTags = function(tags){
   var openTags = "";
@@ -78,7 +163,7 @@ var buildCloseTags = function(tags){
 var getTagsInSelection = function(htmlObject){
   var tags = [];
   var tag;
-  while($(htmlObject)[0].localName != "span"){
+  while($(htmlObject)[0].localName !== "span"){
     var html = $(htmlObject).prop('outerHTML');
     var stylingTagRegex = /<(b|i|u|s)>/.exec(html);
     tag = stylingTagRegex ? stylingTagRegex[1] : "";
@@ -86,43 +171,52 @@ var getTagsInSelection = function(htmlObject){
     htmlObject = $(htmlObject).parent();
   }
   return tags;
-}
+};
 
-exports.addCommentClasses = function(e){
-  var commentId = e.originalEvent.clipboardData.getData('text/copyCommentId');
-  var target = e.target;
-  if (commentId) {
-    // we need to wait the paste process finishes completely, otherwise we will not have the target to add the necessary classes
-    setTimeout(function() {
-      addCommentClassesOnline(target, commentId);
-    }, 0);
+exports.saveCommentsAndReplies = function(e){
+  var comments = e.originalEvent.clipboardData.getData('text/objectComment');
+  var replies = e.originalEvent.clipboardData.getData('text/objectReply');
+
+  if(comments && replies) {
+    setTimeout(function(){
+      comments = JSON.parse(comments);
+      replies = JSON.parse(replies);
+      saveComment(comments, function(){
+        saveReplies(replies);
+      })
+    },0)
   }
 };
 
-var addCommentClassesOnline = function (target, commentId) {
-  var pastingOnEmptyLine = isEmptyLine(target);
-  var targetElement;
-  if (pastingOnEmptyLine){
-    targetElement = $(target).parent();
-  }else{
-    targetElement = getTargetOnLineWithContent();
-  }
-  targetElement.addClass(commentId).addClass('comment');
+var saveComment = function(comments, callback){
+  _.each(comments, function(comment, fakeCommentId){
+    var commentData = buildCommentData(comment, fakeCommentId);
+    pad.plugins.ep_comments_page.saveCommentWithoutSelection(commentData);
+  });
+  callback();
 };
 
-
-var getTargetOnLineWithContent = function() {
-  var padOuter = $('iframe[name="ace_outer"]').contents();
-  var padInner = padOuter.find('iframe[name="ace_inner"]').contents();
-  var target = padInner.find("span[style='background-color: rgb(255, 250, 205);']");
-  return target;
+var saveReplies = function(replies){
+  var repliesToSave = {};
+  var padId = clientVars.padId;
+  var mapOriginalCommentsId = pad.plugins.ep_comments_page.mapOriginalCommentsId;
+  _.each(replies, function(reply, replyId){
+    var originalCommentId = reply.commentId;
+    // as the comment copied has got a new commentId, we set this id in the reply as well
+    reply.commentId = mapOriginalCommentsId[originalCommentId];
+    repliesToSave[replyId] = reply;
+  });
+  pad.plugins.ep_comments_page.saveCommentReplies(padId, repliesToSave);
 };
 
-// an empty line has only a <br>
-var isEmptyLine = function(target) {
-  return $(target).is("br");
+var buildCommentData = function(comment, fakeCommentId){
+  var commentData = {};
+  commentData.comment = {};
+  commentData.padId = clientVars.padId;
+  commentData.comment = comment.data;
+  commentData.comment.commentId = fakeCommentId;
+  return commentData;
 };
-
 // copied from https://css-tricks.com/snippets/javascript/unescape-html-in-js/
 var htmlDecode = function(input) {
   var e = document.createElement('div');
@@ -133,9 +227,75 @@ var htmlDecode = function(input) {
 exports.getCommentIdOnSelection = function() {
   var attributeManager = this.documentAttributeManager;
   var rep = this.rep;
-  var selStartAttrib = _.object(attributeManager.getAttributesOnPosition(rep.selStart[0], rep.selStart[1])).comment;
-  var selEndAttrib = _.object(attributeManager.getAttributesOnPosition(rep.selEnd[0], rep.selEnd[1] - 1)).comment;
-  return selStartAttrib === selEndAttrib ? selStartAttrib : null;
+  var commentId = _.object(attributeManager.getAttributesOnPosition(rep.selStart[0], rep.selStart[1])).comment;
+  return commentId;
 };
 
+exports.hasCommentOnSelection = function() {
+  var hasComment;
+  var attributeManager = this.documentAttributeManager;
+  var rep = this.rep;
+  var firstLineOfSelection = rep.selStart[0];
+  var firstColumn = rep.selStart[1];
+  var lastColumn = rep.selEnd[1];
+  var lastLineOfSelection = rep.selEnd[0];
+  var selectionOfMultipleLine = hasMultipleLineSelected(firstLineOfSelection, lastLineOfSelection);
 
+  if(selectionOfMultipleLine){
+    hasComment = hasCommentOnMultipleLineSelection(firstLineOfSelection,lastLineOfSelection, rep, attributeManager);
+  }else{
+    hasComment = hasCommentOnLine(firstLineOfSelection, firstColumn, lastColumn, attributeManager)
+  }
+  return hasComment;
+};
+
+var hasCommentOnMultipleLineSelection = function(firstLineOfSelection, lastLineOfSelection, rep, attributeManager){
+  var line = firstLineOfSelection;
+  var multipleLineSelectionHasComment = false;
+  for (line; line <= lastLineOfSelection; line++) {
+    var firstColumn = getFirstColumnOfSelection(line, rep, firstLineOfSelection);
+    var lastColumn = getLastColumnOfSelection(line, rep, lastLineOfSelection);
+    var hasComment = hasCommentOnLine(line, firstColumn, lastColumn, attributeManager)
+    if (hasComment){
+      multipleLineSelectionHasComment = true;
+    }
+  }
+  return multipleLineSelectionHasComment;
+};
+
+var getFirstColumnOfSelection = function(line, rep, firstLineOfSelection){
+  return line !== firstLineOfSelection ? 0 : rep.selStart[1];
+};
+
+var getLastColumnOfSelection = function(line, rep, lastLineOfSelection){
+  var lineLength = getLength(line, rep);
+  var positionOfLastCharacterSelected = rep.selEnd[1] - 1;
+  return line !== lastLineOfSelection ? lineLength : positionOfLastCharacterSelected;
+};
+
+var hasCommentOnLine = function(lineNumber, firstColumn, lastColumn, attributeManager){
+  var column = firstColumn;
+  var hasComment = false;
+  for (column; column <= lastColumn; column++) {
+   var commentId = _.object(attributeManager.getAttributesOnPosition(lineNumber, column)).comment;
+   if (commentId !== undefined){
+    hasComment = true;
+   }
+  }
+  return hasComment;
+};
+
+var hasMultipleLineSelected = function(firstLineOfSelection, lastLineOfSelection){
+  return  firstLineOfSelection !== lastLineOfSelection;
+};
+
+var getLength = function(line, rep) {
+  var nextLine = line + 1;
+  var startLineOffset = rep.lines.offsetOfIndex(line);
+  var endLineOffset   = rep.lines.offsetOfIndex(nextLine);
+
+  //lineLength without \n
+  var lineLength = endLineOffset - startLineOffset - 1;
+
+  return lineLength;
+};

--- a/static/js/copyPasteEvents.js
+++ b/static/js/copyPasteEvents.js
@@ -21,7 +21,7 @@ exports.addTextOnClipboard = function(e, ace, padInner, removeSelection, comment
     //'rawHtml' will be 'de', not '<b>de</b>'. As it is not possible to have two comments in the same text
     // commentIdOnFirstPositionSelected is the commentId in this partial selection
     if (onlyTextIsSelected) {
-      var textSelected = rawHtml[0].outerText;
+      var textSelected = rawHtml[0].textContent;
       html = buildHtmlToCopyWhenSelectionHasOnlyText(textSelected, range, commentIdOnFirstPositionSelected);
     }
     var commentIds = getCommentIds(html);

--- a/static/js/copyPasteEvents.js
+++ b/static/js/copyPasteEvents.js
@@ -1,5 +1,6 @@
 var randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
 var _ = require('ep_etherpad-lite/static/js/underscore');
+var shared = require('./shared');
 
 exports.addTextOnClipboard = function(e, ace, padInner, removeSelection, comments, replies){
   var commentIdOnFirstPositionSelected;
@@ -207,10 +208,21 @@ exports.saveCommentsAndReplies = function(e){
 };
 
 var saveComments = function(comments){
+  var commentsToSave = {};
+  var padId = clientVars.padId;
+
+  var mapOriginalCommentsId = pad.plugins.ep_comments_page.mapOriginalCommentsId;
+  var mapFakeComments = pad.plugins.ep_comments_page.mapFakeComments;
+
   _.each(comments, function(comment, fakeCommentId){
     var commentData = buildCommentData(comment, fakeCommentId);
-    pad.plugins.ep_comments_page.saveCommentWithoutSelection(commentData);
+    var newCommentId = shared.generateCommentId();
+    mapFakeComments[fakeCommentId] = newCommentId;
+    var originalCommentId = comment.data.originalCommentId;
+    mapOriginalCommentsId[originalCommentId] = newCommentId;
+    commentsToSave[newCommentId] = comment;
   });
+  pad.plugins.ep_comments_page.saveCommentWithoutSelection(padId, commentsToSave);
 };
 
 var saveReplies = function(replies){

--- a/static/js/copyPasteEvents.js
+++ b/static/js/copyPasteEvents.js
@@ -178,13 +178,11 @@ exports.saveCommentsAndReplies = function(e){
   var replies = e.originalEvent.clipboardData.getData('text/objectReply');
 
   if(comments && replies) {
-    setTimeout(function(){
-      comments = JSON.parse(comments);
-      replies = JSON.parse(replies);
-      saveComment(comments, function(){
-        saveReplies(replies);
-      })
-    },0)
+    comments = JSON.parse(comments);
+    replies = JSON.parse(replies);
+    saveComment(comments, function(){
+      saveReplies(replies);
+    });
   }
 };
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -96,8 +96,12 @@ ep_comments.prototype.init = function(){
     // console.log('pushComment', comment);
     window.setTimeout(function() {
       self.collectComments();
+
       var count_comments=0;
       for(var key in self.comments)  {count_comments++;}
+      var padOuter = $('iframe[name="ace_outer"]').contents();
+      this.padOuter = padOuter;
+      this.padInner = padOuter.find('iframe[name="ace_inner"]');
       var padComment  = this.padInner.contents().find('.comment');
       if( count_comments > padComment.length ) {
          window.setTimeout(function() {
@@ -710,8 +714,10 @@ ep_comments.prototype.setComment = function(commentId, comment){
   var comments = this.comments;
   comment.date = prettyDate(comment.timestamp);
   comment.formattedDate = new Date(comment.timestamp).toISOString();
+
   if (comments[commentId] == null) comments[commentId] = {};
   comments[commentId].data = comment;
+
 };
 
 ep_comments.prototype.setCommentReply = function(commentReply){
@@ -881,7 +887,7 @@ ep_comments.prototype.getFirstElementSelected = function(){
 
 // Indicates if user selected some text on editor
 ep_comments.prototype.checkNoTextSelected = function(rep) {
-  var noTextSelected = (rep.selStart[0] == rep.selEnd[0] && rep.selStart[1] == rep.selEnd[1]);
+  var noTextSelected = ((rep.selStart[0] == rep.selEnd[0]) && (rep.selStart[1] == rep.selEnd[1]));
 
   return noTextSelected;
 }
@@ -1009,11 +1015,12 @@ ep_comments.prototype.saveCommentWithoutSelection = function (data) {
   var originalCommentId = data.comment.originalCommentId;
   self.mapOriginalCommentsId[originalCommentId] = newCommentId;
   data.comment.commentId = newCommentId;
-  self.socket.emit('addComment', data, function (commentId, comment){
-    comment.commentId = commentId;
-    self.setComment(commentId, comment);
-    self.shouldCollectComment = true;
-  });
+  self.socket.emit('addComment', data, function (commentId, comment){});
+
+  var commentId = data.comment.commentId;
+  var comment = data.comment;
+  self.setComment(commentId, comment);
+  self.shouldCollectComment = true;
 }
 
  ep_comments.prototype.generateCommentId = function(){
@@ -1162,7 +1169,7 @@ var hooks = {
     var commentWasPasted = pad.plugins.ep_comments_page.shouldCollectComment;
     var domClean = context.callstack.domClean;
     // we have to wait the DOM update from a fakeComment 'fakecomment-123' to a comment class 'c-123'
-    if(commentWasPasted && domClean == true){
+    if(commentWasPasted && domClean){
       pad.plugins.ep_comments_page.collectComments(function(){
         pad.plugins.ep_comments_page.collectCommentReplies();
         pad.plugins.ep_comments_page.shouldCollectComment = false;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1008,19 +1008,18 @@ ep_comments.prototype.saveComment = function(data, rep) {
 }
 
 ep_comments.prototype.saveCommentWithoutSelection = function (data) {
-  var self = this;
   var fakeCommentId = data.comment.commentId;
-  var newCommentId =  self.generateCommentId();
-  self.mapFakeComments[fakeCommentId] = newCommentId;
+  var newCommentId =  this.generateCommentId();
+  this.mapFakeComments[fakeCommentId] = newCommentId;
   var originalCommentId = data.comment.originalCommentId;
-  self.mapOriginalCommentsId[originalCommentId] = newCommentId;
+  this.mapOriginalCommentsId[originalCommentId] = newCommentId;
   data.comment.commentId = newCommentId;
-  self.socket.emit('addComment', data, function (commentId, comment){});
+  this.socket.emit('addComment', data, function (commentId, comment){});
 
   var commentId = data.comment.commentId;
   var comment = data.comment;
-  self.setComment(commentId, comment);
-  self.shouldCollectComment = true;
+  this.setComment(commentId, comment);
+  this.shouldCollectComment = true;
 }
 
  ep_comments.prototype.generateCommentId = function(){

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -327,7 +327,7 @@ ep_comments.prototype.init = function(){
   // text<comment class='comment'><span>to be copied</span></comment>
   if(browser.chrome){
     self.padInner.contents().on("copy", function(e) {
-      events.addTextOnClipboard(e, self.ace, self.padInner, false, allComments, self.commentReplies);
+      events.addTextOnClipboard(e, self.ace, self.padInner, false, self.comments, self.commentReplies);
     });
 
     self.padInner.contents().on("cut", function(e) {

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -21,8 +21,6 @@ var getCommentIdOnFirstPositionSelected = events.getCommentIdOnFirstPositionSele
 var hasCommentOnSelection = events.hasCommentOnSelection;
 var browser = require('ep_etherpad-lite/static/js/browser');
 
-var randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
-
 var cssFiles = ['ep_comments_page/static/css/comment.css', 'ep_comments_page/static/css/commentIcon.css'];
 
 var UPDATE_COMMENT_LINE_POSITION_EVENT = 'updateCommentLinePosition';
@@ -323,7 +321,8 @@ ep_comments.prototype.init = function(){
     self.container.addClass("active");
   }
 
-  // Override  copy, cut, paste events on Google chrome.
+  // TODO - Implement to others browser like, Microsoft Edge, Opera, IE
+  // Override  copy, cut, paste events on Google chrome and Mozilla Firefox.
   // When an user copies a comment and selects only the span, or part of it, Google chrome
   // does not copy the classes only the styles, for example:
   // <comment class='comment'><span>text to be copied</span></comment>
@@ -720,10 +719,11 @@ ep_comments.prototype.setComment = function(commentId, comment){
 
 };
 
+// commentReply = ['c-reply-123', commentDataObject]
+// commentDataObject = {author:..., name:..., text:..., ...}
 ep_comments.prototype.setCommentReply = function(commentReply){
   var commentReplies = this.commentReplies;
   var replyId = commentReply[0];
-  if(commentReplies[replyId] == null) commentReplies[replyId] = {}
   commentReplies[replyId] = commentReply[1];
 };
 
@@ -1050,7 +1050,8 @@ ep_comments.prototype.saveCommentWithoutSelection = function (data) {
 
  // take a replyData and add more fields necessary. E.g. 'padId'
  ep_comments.prototype.buildCommentReply = function(replyData){
-   var data = this.getCommentData();
+   var data = {};
+   data.padId = this.padId;
    data.commentId = replyData.commentId;
    data.text = replyData.text;
    data.changeTo = replyData.changeTo

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -330,7 +330,7 @@ ep_comments.prototype.init = function(){
   // As the comment classes are not only used for styling we have to add these classes when it pastes the content
   // The same does not occur when the user selects more than the span, for example:
   // text<comment class='comment'><span>to be copied</span></comment>
-  if(browser.chrome){
+  if(browser.chrome || browser.firefox){
     self.padInner.contents().on("copy", function(e) {
       events.addTextOnClipboard(e, self.ace, self.padInner, false, self.comments, self.commentReplies);
     });
@@ -365,7 +365,6 @@ ep_comments.prototype.collectComments = function(callback){
     var cls             = $this.attr('class');
     var classCommentId  = /(?:^| )(c-[A-Za-z0-9]*)/.exec(cls);
     var commentId       = (classCommentId) ? classCommentId[1] : null;
-
     if(!commentId){
       // console.log("returning due to no comment id, probably due to a deleted comment");
       return;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1035,8 +1035,8 @@ ep_comments.prototype.saveCommentWithoutSelection = function (data) {
    self.socket.emit('bulkAddCommentReplies', padId, data, function (replies){
     _.each(replies,function(reply){
       self.setCommentReply(reply);
-      // the comment reply is collected together with the comment
     });
+    self.shouldCollectComment = true; // force collect the comment replies saved
    });
  }
 

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -1,3 +1,5 @@
+var randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
+
 var collectContentPre = function(hook, context){
   var comment = /(?:^| )(c-[A-Za-z0-9]*)/.exec(context.cls);
   var fakeComment = /(?:^| )(fakecomment-[A-Za-z0-9]*)/.exec(context.cls);
@@ -5,8 +7,10 @@ var collectContentPre = function(hook, context){
   if(comment && comment[1]){
     context.cc.doAttrib(context.state, "comment::" + comment[1]);
   }
-  // a fake comment, it is a comment copied. To avoid conflicts, it is used a fake commentId, so then we generate a new one when
-  // it saves the comment.
+
+  // a fake comment is a comment copied from this or another pad. To avoid conflicts
+  // with existing comments, a fake commentId is used, so then we generate a new one
+  // when the comment is saved
   if(fakeComment){
     var mapFakeComments = pad.plugins.ep_comments_page.getMapfakeComments();
     var fakeCommentId = fakeComment[1];
@@ -16,3 +20,9 @@ var collectContentPre = function(hook, context){
 };
 
 exports.collectContentPre = collectContentPre;
+
+
+exports.generateCommentId = function(){
+   var commentId = "c-" + randomString(16);
+   return commentId;
+}

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -1,7 +1,17 @@
 var collectContentPre = function(hook, context){
   var comment = /(?:^| )(c-[A-Za-z0-9]*)/.exec(context.cls);
+  var fakeComment = /(?:^| )(fakecomment-[A-Za-z0-9]*)/.exec(context.cls);
+
   if(comment && comment[1]){
     context.cc.doAttrib(context.state, "comment::" + comment[1]);
+  }
+  // a fake comment, it is a comment copied. To avoid conflicts, it is used a fake commentId, so then we generate a new one when
+  // it saves the comment.
+  if(fakeComment){
+    var mapFakeComments = pad.plugins.ep_comments_page.getMapfakeComments();
+    var fakeCommentId = fakeComment[1];
+    var commentId = mapFakeComments[fakeCommentId];
+    context.cc.doAttrib(context.state, "comment::" + commentId);
   }
 };
 

--- a/static/tests/frontend/specs/commentCopyPaste.js
+++ b/static/tests/frontend/specs/commentCopyPaste.js
@@ -1,0 +1,372 @@
+describe('Comment copy and paste', function () {
+  var helperFunctions, event;
+
+  var FIRST_LINE = 0;
+  var SECOND_LINE = 1;
+
+  before(function(cb){
+    helperFunctions = ep_comments_page_test_helper.copyAndPaste;
+    helperFunctions.createPad(this, cb);
+  });
+
+  context('when user copies a text with a comment', function(){
+    var commentText = 'My comment';
+    var replyText = 'A reply';
+    before(function (cb) {
+      helperFunctions.addComentAndReplyToLine(FIRST_LINE, commentText, replyText, function(){
+        event = helperFunctions.copyLine();
+        cb();
+      });
+    });
+
+    // create a new pad after the tests of paste run
+    after(function(cb) {
+      helperFunctions.createPad(this, cb);
+    });
+
+    it('keeps the text copied on the buffer', function (done) {
+      var dataFromGetData = event.originalEvent.clipboardData.getData('text/html');
+      var $dataFromGetData = $(dataFromGetData);
+      var textCopied = helperFunctions.cleanText($dataFromGetData.text());
+      var hasCopiedSpanTag = $dataFromGetData.filter('span').length === 1;
+      expect(textCopied).to.be('something ');
+      expect(hasCopiedSpanTag).to.be(true);
+      done();
+    });
+
+    it('generates a fake comment class', function(done) {
+      var dataFromGetData = event.originalEvent.clipboardData.getData('text/html');
+      var $dataFromGetData = $(dataFromGetData);
+      var classes = $dataFromGetData.attr('class');
+      var hasFakerCommentClass = classes.match(/(fakecomment-)([a-zA-Z0-9]{16}$)/).length > 0;
+      expect(hasFakerCommentClass).to.be(true);
+      done();
+    });
+
+    it('puts the comment data on the clipboardData', function(done) {
+      var commentDataValues = helperFunctions.getCommentDataValues(event);
+      var originalCommentId = helperFunctions.getCommentIdOfLine(FIRST_LINE);
+      var textOfCommentOnClipboard = commentDataValues.text;
+      var idOfOriginalCommentOnClipboard = commentDataValues.originalCommentId;
+      expect(textOfCommentOnClipboard).to.be(commentText);
+      expect(idOfOriginalCommentOnClipboard).to.be(originalCommentId)
+      done();
+    });
+
+    it('puts the comment reply data on the clipboardData', function(done) {
+      var commentReplyDataValues = helperFunctions.getCommentReplyDataValues(event);
+      var textOfCommentOnClipboard = commentReplyDataValues.text;
+      expect(textOfCommentOnClipboard).to.be(replyText);
+      done();
+    });
+
+    it('has the fields required to build a comment', function(done) {
+      var commentDataValues = helperFunctions.getCommentDataValues(event);
+      var keys = _.keys(commentDataValues);
+      var keysLength = keys.length;
+      var keysRequired = ["author", "name", "text", "timestamp", "commentId", "date", "formattedDate", "originalCommentId"];
+      var containsAllKeys = _.difference(keys, keysRequired).length === 0;
+      expect(keysLength).to.be(8);
+      expect(containsAllKeys).to.be(true);
+      done();
+    });
+
+    it('has the fields required to build a comment reply', function(done) {
+      var commentReplyDataValues = helperFunctions.getCommentReplyDataValues(event);
+      var keys = _.keys(commentReplyDataValues);
+      var keysLength = keys.length;
+      var keysRequired = ["commentId", "text", "changeTo", "changeFrom", "author", "name", "timestamp", "replyId", "formattedDate"];
+      var containsAllKeys = _.difference(keys, keysRequired).length === 0;
+      expect(keysLength).to.be(9);
+      expect(containsAllKeys).to.be(true);
+      done();
+    });
+  });
+
+  context('when user pastes a text with comment', function() {
+    var commentText = 'My comment 2';
+    var replyText = 'Reply 2';
+    before(function (cb) {
+      helperFunctions.enlargeScreen(function(){
+        helperFunctions.addComentAndReplyToLine(FIRST_LINE, commentText, replyText, function(){
+          event = helperFunctions.copyLine();
+          helperFunctions.pasteTextOnLine(event, SECOND_LINE);
+          cb();
+        });
+      });
+    });
+
+    it('generates a different comment id for the comment pasted', function (done) {
+      var commentIdOriginal = helperFunctions.getCommentIdOfLine(FIRST_LINE);
+      var commentIdLinePasted = null;
+      // wait for the new comment to be created
+      helper.waitFor(function(){
+        commentIdLinePasted = helperFunctions.getCommentIdOfLine(SECOND_LINE);
+        return commentIdLinePasted !== null;
+      }).done(function(){
+        var commentsHasDifferentIds = commentIdOriginal !== commentIdLinePasted;
+        expect(commentsHasDifferentIds).to.be(true);
+        done();
+      });
+    });
+
+    it('creates a new icon for the comment pasted', function(done) {
+      helperFunctions.finishTestIfIconsAreNotEnabled(done, function(){
+        helperFunctions.createdCommentOnLine(SECOND_LINE, function(){
+          var outer$ = helper.padOuter$;
+
+          // for some reason appears a comment reply icon on top
+          var $commentIcon = outer$('.comment-icon');
+          expect($commentIcon.length).to.be(2);
+          done();
+        });
+      });
+    });
+
+    it('keeps the comment text', function(done) {
+      helperFunctions.createdCommentOnLine(SECOND_LINE, function(){
+        var commentPastedText = helperFunctions.getTextOfCommentFromLine(SECOND_LINE);
+        expect(commentPastedText).to.be(commentText);
+        done();
+      });
+    });
+
+    it('keeps the comment reply text', function(done) {
+      helperFunctions.createdCommentOnLine(SECOND_LINE, function(){
+        var commentReplyText = helperFunctions.getTextOfCommentReplyFromLine(SECOND_LINE);
+        expect(commentReplyText).to.be(replyText);
+        done();
+      });
+    });
+
+    context('when user removes the original comment', function(){
+
+      it('does not remove the comment pasted', function (done) {
+        helperFunctions.createdCommentOnLine(SECOND_LINE, function(){
+          helperFunctions.removeCommentFromLine(FIRST_LINE, function(){
+            var inner$ = helper.padInner$;
+            var commentsLength = inner$('.comment').length;
+            expect(commentsLength).to.be(1);
+            done();
+          });
+        });
+      });
+    });
+  });
+});
+
+var ep_comments_page_test_helper = ep_comments_page_test_helper || {};
+ep_comments_page_test_helper.copyAndPaste = {
+  createPad: function(test, cb) {
+    var self = this;
+    helper.newPad(function(){
+      self.createPadText();
+      cb();
+    });
+    test.timeout(60000);
+  },
+  createPadText: function() {
+    var inner$ = helper.padInner$;
+    inner$('div').first().sendkeys('something \n');
+  },
+  addComentAndReplyToLine: function(line, textOfComment, textOfReply, callback) {
+    var self = this;
+    this.addCommentToLine(line, textOfComment, function(){
+      self.addCommentReplyToLine(line, textOfReply, callback);
+    });
+  },
+  deleteComment: function(callback){
+    var chrome$ = helper.padChrome$;
+    var outer$ = helper.padOuter$;
+
+    //click on the settings button to make settings visible
+    var $deleteButton = outer$(".comment-delete");
+    $deleteButton.click();
+
+    helper.waitFor(function() {
+      return chrome$(".sidebar-comment").is(":visible") === false;
+    })
+    .done(callback);
+  },
+  addCommentReplyToLine: function(line, textOfReply, callback) {
+    var outer$ = helper.padOuter$;
+    var commentId = this.getCommentIdOfLine(line);
+    var existingReplies = outer$(".sidebar-comment-reply").length;
+
+    // if comment icons are enabled, make sure we display the comment box:
+    if (this.commentIconsEnabled()) {
+      // click on the icon
+      var $commentIcon = outer$("#commentIcons #icon-"+commentId).first();
+      $commentIcon.click();
+    }
+
+    // fill reply field
+    var $replyField = outer$(".comment-reply-input");
+    $replyField.val(textOfReply);
+
+    // submit reply
+    var $submitReplyButton = outer$("form.comment-reply input[type='submit']").first();
+    $submitReplyButton.click();
+
+    // wait for the reply to be saved
+    helper.waitFor(function() {
+      return outer$(".sidebar-comment-reply").length === existingReplies + 1;
+    }).done(callback);
+  },
+  commentIconsEnabled: function() {
+    return helper.padOuter$("#commentIcons").length > 0;
+  },
+  addCommentToLine: function(line, textOfComment, callback) {
+    var outer$ = helper.padOuter$;
+    var chrome$ = helper.padChrome$;
+    var $line = this.getLine(line);
+    $line.sendkeys('{selectall}'); // needs to select content to add comment to
+    var $commentButton = chrome$(".addComment");
+    $commentButton.click();
+
+    // fill the comment form and submit it
+    var $commentField = outer$("textarea.comment-content");
+    $commentField.val(textOfComment);
+    var $submittButton = outer$("input[type=submit]");
+    $submittButton.click();
+
+    // wait until comment is created and comment id is set
+    this.createdCommentOnLine(line, callback);
+  },
+  removeCommentFromLine: function(line, cb) {
+    var outer$ = helper.padOuter$;
+    var commentId = this.getCommentIdOfLine(line);
+
+    // click in the comment icon
+    var $secondCommentIcon = outer$("#commentIcons #icon-"+ commentId);
+    $secondCommentIcon.click();
+
+    // press delete on sidebar comment
+    var $deleteButton = outer$(".comment-delete").slice(line, line + 1);
+    $deleteButton.click();
+    cb();
+  },
+  createdCommentOnLine: function(line, cb) {
+    var self = this;
+    helper.waitFor(function() {
+      return self.getCommentIdOfLine(line) !== null;
+    }).done(cb);
+  },
+  copyLine: function(){
+    var chrome$ = helper.padChrome$;
+    var inner$ = helper.padInner$;
+
+    // store data into a simple object, indexed by format
+    var clipboardDataMock = {
+     data: {},
+     setData: function(format, value) {
+       this.data[format] = value;
+     },
+     getData: function(format) {
+       return this.data[format];
+     }
+    };
+
+    var event = jQuery.Event("copy");
+    var e = {clipboardData: clipboardDataMock};
+    event.originalEvent = e;
+
+    // Hack: we need to use the same jQuery instance that is registering the main window,
+    // so we use "chrome$(inner$("div")[0])" instead of simply "inner$("div)"
+    chrome$(inner$("div")[0]).trigger(event);
+    return event;
+  },
+  pasteTextOnLine: function(event, line) {
+    var chrome$ = helper.padChrome$;
+    var inner$ = helper.padInner$;
+    var e = event;
+    e.type = "paste";
+
+    // Hack: we need to use the same jQuery instance that is registering the main window,
+    // so we use "chrome$(inner$("div")[0])" instead of simply "inner$("div)"
+    chrome$(inner$("div")[0]).trigger(event);
+
+    // as we can't trigger the paste on browser(chrome) natively using execCommand, we firstly trigger
+    // the event and then insert the html.
+    this.placeCaretOnLine(line, function(){
+      var copiedHTML = event.originalEvent.clipboardData.getData('text/html');
+      helper.padInner$.document.execCommand('insertHTML', true, copiedHTML);
+    });
+  },
+  placeCaretOnLine: function(lineNum, cb) {
+    var self = this;
+    var $targetLine = this.getLine(lineNum);
+    $targetLine.sendkeys("{selectall}");
+
+    helper.waitFor(function() {
+     var $targetLine = self.getLine(lineNum);
+     var $lineWhereCaretIs = self.getLineWhereCaretIs();
+
+     return $targetLine.get(0) === $lineWhereCaretIs.get(0);
+    }).done(cb);
+  },
+  getLine: function(lineNum) {
+    var inner$ = helper.padInner$;
+    var $line = inner$('div').slice(lineNum, lineNum + 1);
+    return $line;
+  },
+  getLineWhereCaretIs: function() {
+    var inner$ = helper.padInner$;
+    var nodeWhereCaretIs = inner$.document.getSelection().anchorNode;
+    var $lineWhereCaretIs = $(nodeWhereCaretIs).closest("div");
+    return $lineWhereCaretIs;
+  },
+  cleanText: function(text) {
+    return text.replace(/\s/gi, " ");
+  },
+  getCommentIdOfLine: function(line) {
+    var $line = this.getLine(line);
+    var comment = $line.find(".comment");
+    var cls = comment.attr('class');
+    var classCommentId = /(?:^| )(c-[A-Za-z0-9]*)/.exec(cls);
+    var commentId = (classCommentId) ? classCommentId[1] : null;
+
+    return commentId;
+  },
+  getCommentDataValues: function(event) {
+    var commentData = event.originalEvent.clipboardData.getData('text/objectComment');
+    var commentDataJSON = JSON.parse(commentData);
+    var commentDataValues = _.values(commentDataJSON)[0].data;
+    return commentDataValues;
+  },
+  getCommentReplyDataValues: function(event) {
+    var commentReplyData = event.originalEvent.clipboardData.getData('text/objectReply');
+    var commentReplyDataJSON = JSON.parse(commentReplyData);
+    var commentReplyDataValues = _.values(commentReplyDataJSON)[0];
+    return commentReplyDataValues;
+  },
+  enlargeScreen: function(callback) {
+    $('#iframe-container iframe').css("max-width", "1000px");
+    callback();
+  },
+  getTextOfCommentFromLine: function (line) {
+    var outer$ = helper.padOuter$;
+    var $secondCommentIcon = outer$("#commentIcons #icon-"+ this.getCommentIdOfLine(line));
+    $secondCommentIcon.click();
+
+    // check modal is visible
+    var commentPastedText = outer$("#comments .sidebar-comment:visible .comment-text").first().text();
+    return commentPastedText;
+  },
+  getTextOfCommentReplyFromLine: function (line) {
+    var outer$ = helper.padOuter$;
+    var $secondCommentIcon = outer$("#commentIcons #icon-"+ this.getCommentIdOfLine(line));
+    $secondCommentIcon.click();
+
+    var commentPastedText = outer$("#" + this.getCommentIdOfLine(line) + " .comment-reply .comment-text").text();
+    return commentPastedText;
+  },
+  finishTestIfIconsAreNotEnabled: function(done, theTest) {
+    // #commentIcons will only be inserted if icons are enabled
+    if (helper.padOuter$("#commentIcons").length === 0){
+      done();
+    }else{
+      theTest(done);
+    }
+  },
+};

--- a/static/tests/frontend/specs/commentCopyPaste.js
+++ b/static/tests/frontend/specs/commentCopyPaste.js
@@ -1,4 +1,4 @@
-describe('Comment copy and paste', function () {
+describe('ep_comments_page - Comment copy and paste', function () {
   var helperFunctions, event;
 
   var FIRST_LINE = 0;

--- a/static/tests/frontend/specs/commentCopyPaste.js
+++ b/static/tests/frontend/specs/commentCopyPaste.js
@@ -14,6 +14,8 @@ describe('ep_comments_page - Comment copy and paste', function () {
     before(function (cb) {
       helperFunctions.createPad(this, function(){
         helperFunctions.addComentAndReplyToLine(FIRST_LINE, commentText, replyText, function(){
+          var $firstLine = helper.padInner$('div').eq(0);
+          helper.selectLines($firstLine, $firstLine, 1, 8); //'omethin'
           event = helperFunctions.copyLine();
           cb();
         });
@@ -28,7 +30,7 @@ describe('ep_comments_page - Comment copy and paste', function () {
 
       // we create two spans to avoid error on paste on chrome, when we copy only a text without tags
       var hasCopiedSpanTag = $dataFromGetData.filter('span').length === 2;
-      expect(textCopied).to.be('something');
+      expect(textCopied).to.be('omethin');
       expect(hasCopiedSpanTag).to.be(true);
       done();
     });
@@ -82,7 +84,7 @@ describe('ep_comments_page - Comment copy and paste', function () {
           });
         });
       });
-      this.timeout(10000);
+      this.timeout(20000);
     });
 
     it('generates a different comment id for the comment pasted', function (done) {
@@ -295,7 +297,7 @@ ep_comments_page_test_helper.copyAndPaste = {
     // the event and then insert the html.
     this.placeCaretOnLine(line, function(){
       var copiedHTML = event.originalEvent.clipboardData.getData('text/html');
-      helper.padInner$.document.execCommand('insertHTML', true, copiedHTML);
+      helper.padInner$.document.execCommand('insertHTML', false, copiedHTML);
     });
   },
   placeCaretOnLine: function(lineNum, cb) {


### PR DESCRIPTION
This PR enables to copy a comment from a pad to another. 

We've been using it for 1 year. This has been tested on 
Ubuntu 14.04, Ubuntu 16.04 (chrome 45 - 57, Firefox 56)
Mac Os (chrome 55 - 57)
Windows (chrome 55 - 57, firefox 53)

_Limitations_ 

*It does not paste a comment when user copies only one character of a text with comment_