### PR TITLE
Add a timeout of 2 seconds before closing a comment.

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -586,7 +586,12 @@ ep_comments.prototype.addListenersToCloseOpenedComment = function() {
 // Close comment that is opened
 ep_comments.prototype.closeOpenedComment = function(e) {
   var commentId = this.commentIdOf(e);
-  commentBoxes.hideComment(commentId);
+  // Add a timeout of 3 seconds before closing the comment.
+  // If there are two comments on the same line, this gives the user the time
+  // to click the comment window before it gets closed.
+  setTimeout(function(){
+    commentBoxes.hideComment(commentId);
+  }, 3000);
 }
 
 // Close comment if event target was outside of comment or on a comment icon
@@ -1452,4 +1457,3 @@ exports.aceInitialized = function(hook, context){
   editorInfo.ace_getCommentIdOnFirstPositionSelected = _(getCommentIdOnFirstPositionSelected).bind(context);
   editorInfo.ace_hasCommentOnSelection = _(hasCommentOnSelection).bind(context);
 }
-


### PR DESCRIPTION
If there are two or more comments on the same line, the user can only reply to the last one. If he hovers the mouse over a commented section, the comment window will disappear as soon as the pointer leaves the commented section.

This pull request aims to fix that problem by adding a timeout. I don't know if this is the correct approach. If it's not the case, please give me some advice and I will be happy to update this pull request.