### PR TITLE
tests: Fix accidental treatment of `getCommentId` as synchronous

### DIFF
--- a/static/tests/frontend/specs/commentIcons.js
+++ b/static/tests/frontend/specs/commentIcons.js
@@ -10,10 +10,9 @@ describe("ep_comments_page - Comment icons", function() {
     this.timeout(60000);
   });
 
-  after(function(cb) {
+  after(async function() {
     // undo frame resize that was done on before()
     $('#iframe-container iframe').css("max-width", "");
-    cb();
   });
 
   it('adds a comment icon on the same height of commented text', async function() {

--- a/static/tests/frontend/specs/commentIcons.js
+++ b/static/tests/frontend/specs/commentIcons.js
@@ -59,7 +59,7 @@ describe("ep_comments_page - Comment icons", function() {
       var inner$ = helper.padInner$;
       var outer$ = helper.padOuter$;
 
-      await new Promise((resolve) => deleteComment(resolve));
+      await deleteComment();
       // check icon is not visible
       var $commentIcons = outer$("#commentIcons .comment-icon:visible");
       expect($commentIcons.length).to.be(0);
@@ -230,7 +230,7 @@ describe("ep_comments_page - Comment icons", function() {
     await helper.waitForPromise(() => getCommentId(numberOfComments) !== null);
   };
 
-  var deleteComment = function(callback) {
+  const deleteComment = async () => {
     var chrome$ = helper.padChrome$;
     var outer$ = helper.padOuter$;
 
@@ -238,11 +238,8 @@ describe("ep_comments_page - Comment icons", function() {
     var $deleteButton = outer$(".comment-delete");
     $deleteButton.click();
 
-    helper.waitFor(function() {
-      return chrome$(".sidebar-comment").is(":visible") === false;
-    })
-    .done(callback);
-  }
+    await helper.waitForPromise(() => chrome$('.sidebar-comment').is(':visible') === false);
+  };
 
 
   var getCommentId = function(numberOfComments) {

--- a/static/tests/frontend/specs/commentIcons.js
+++ b/static/tests/frontend/specs/commentIcons.js
@@ -162,7 +162,7 @@ describe("ep_comments_page - Comment icons", function() {
       // ... then add a comment to second line
       var $secondLine = inner$("div").eq(1);
       $secondLine.sendkeys('{selectall}');
-      await new Promise((resolve) => addComment('Second Comment', resolve));
+      await addComment('Second Comment');
 
       // click on the icon of first comment...
       var $firstCommentIcon = outer$("#commentIcons #icon-"+getCommentId(0)).first();
@@ -198,12 +198,12 @@ describe("ep_comments_page - Comment icons", function() {
       var $lastTextElement = inner$("div").first();
       $lastTextElement.sendkeys('{selectall}'); // need to select content to add comment to
 
-      addComment("My comment", callback);
+      addComment('My comment').then(callback);
     });
   }
 
   // Assumes text is already selected, then add comment to the selected text
-  var addComment = function(commentText, callback) {
+  const addComment = async (commentText) => {
     var inner$ = helper.padInner$;
     var outer$ = helper.padOuter$;
     var chrome$ = helper.padChrome$;
@@ -227,11 +227,8 @@ describe("ep_comments_page - Comment icons", function() {
     $submittButton.click();
 
     // wait until comment is created and comment id is set
-    helper.waitFor(function() {
-      return getCommentId(numberOfComments) !== null;
-    })
-    .done(callback);
-  }
+    await helper.waitForPromise(() => getCommentId(numberOfComments) !== null);
+  };
 
   var deleteComment = function(callback) {
     var chrome$ = helper.padChrome$;

--- a/static/tests/frontend/specs/commentIcons.js
+++ b/static/tests/frontend/specs/commentIcons.js
@@ -3,12 +3,10 @@ describe("ep_comments_page - Comment icons", function() {
   beforeEach(function(cb){
     helper.newPad(function() {
       // make sure Etherpad has enough space to display comment icons
-      enlargeScreen(function() {
-        // force sidebar comments to be shown
-        chooseToShowComments(true, function() {
-          createComment(cb);
-        });
-      });
+      enlargeScreen();
+      // force sidebar comments to be shown
+      chooseToShowComments(true);
+      createComment(cb);
     });
     this.timeout(60000);
   });
@@ -295,7 +293,7 @@ describe("ep_comments_page - Comment icons", function() {
     else theTest(done);
   }
 
-  var chooseToShowComments = function(shouldShowComments, callback) {
+  const chooseToShowComments = (shouldShowComments) => {
     var chrome$ = helper.padChrome$;
 
     //click on the settings button to make settings visible
@@ -308,13 +306,10 @@ describe("ep_comments_page - Comment icons", function() {
 
     // hide settings again
     $settingsButton.click();
+  };
 
-    callback();
-  }
-
-  var enlargeScreen = function(callback) {
+  const enlargeScreen = () => {
     $('#iframe-container iframe').css("max-width", "1000px");
-    callback();
-  }
+  };
 
 });

--- a/static/tests/frontend/specs/commentIcons.js
+++ b/static/tests/frontend/specs/commentIcons.js
@@ -1,13 +1,12 @@
 describe("ep_comments_page - Comment icons", function() {
   //create a new pad with comment before each test run
-  beforeEach(function(cb){
-    helper.newPad(function() {
-      // make sure Etherpad has enough space to display comment icons
-      enlargeScreen();
-      // force sidebar comments to be shown
-      chooseToShowComments(true);
-      createComment(cb);
-    });
+  beforeEach(async function() {
+    await new Promise((resolve) => helper.newPad(resolve));
+    // make sure Etherpad has enough space to display comment icons
+    enlargeScreen();
+    // force sidebar comments to be shown
+    chooseToShowComments(true);
+    await createComment();
     this.timeout(60000);
   });
 
@@ -179,7 +178,7 @@ describe("ep_comments_page - Comment icons", function() {
 
   /* ********** Helper functions ********** */
 
-  var createComment = function(callback) {
+  const createComment = async () => {
     var inner$ = helper.padInner$;
 
     // get the first text element out of the inner iframe
@@ -190,16 +189,13 @@ describe("ep_comments_page - Comment icons", function() {
     $firstTextElement.sendkeys('{del}'); // clear the first line
     $firstTextElement.sendkeys('This content will receive a comment{enter}'); // insert text
     // wait until the two lines are split into two .ace-line's
-    helper.waitFor(function() {
-      return inner$("div").length > 1;
-    })
-    .done(function() {
-      // add comment to last line of the text
-      var $lastTextElement = inner$("div").first();
-      $lastTextElement.sendkeys('{selectall}'); // need to select content to add comment to
+    await helper.waitForPromise(() => inner$("div").length > 1);
 
-      addComment('My comment').then(callback);
-    });
+    // add comment to last line of the text
+    var $lastTextElement = inner$("div").first();
+    $lastTextElement.sendkeys('{selectall}'); // need to select content to add comment to
+
+    await addComment('My comment');
   }
 
   // Assumes text is already selected, then add comment to the selected text

--- a/static/tests/frontend/specs/commentIcons.js
+++ b/static/tests/frontend/specs/commentIcons.js
@@ -17,9 +17,9 @@ describe("ep_comments_page - Comment icons", function() {
     cb();
   });
 
-  it("adds a comment icon on the same height of commented text", function(done) {
+  it('adds a comment icon on the same height of commented text', async function() {
     // we only run test if icons are enabled
-    finishTestIfIconsAreNotEnabled(done, function(){
+    await finishTestIfIconsAreNotEnabled(async () => {
       var inner$ = helper.padInner$;
       var outer$ = helper.padOuter$;
       var commentId = getCommentId();
@@ -32,14 +32,12 @@ describe("ep_comments_page - Comment icons", function() {
       var $commentedText = inner$("."+commentId);
       var expectedTop = $commentedText.offset().top + 5; // all icons are +5px down to adjust position
       expect($commentIcon.offset().top).to.be(expectedTop);
-
-      done();
     });
   });
   // TODO: Needs fixing
-  xit("does not show comment icon when commented text is removed", function(done) {
+  xit('does not show comment icon when commented text is removed', async function() {
     // we only run test if icons are enabled
-    finishTestIfIconsAreNotEnabled(done, function(){
+    await finishTestIfIconsAreNotEnabled(async () => {
       var inner$ = helper.padInner$;
       var outer$ = helper.padOuter$;
       // remove commented text
@@ -47,34 +45,30 @@ describe("ep_comments_page - Comment icons", function() {
       $commentedLine.sendkeys('{selectall}'); // select all
       $commentedLine.sendkeys('{del}'); // clear the first line
       // wait until comment deletion is done
-      helper.waitFor(function() {
+      await helper.waitForPromise(() => {
         // check icon is not visible
         var $commentIcons = outer$("#commentIcons .comment-icon:visible");
         return $commentIcons.length === 0;
-      })
-      .done(done);
-    });
-  });
-  // TODO: Needs fixing
-  xit("does not show comment icon when comment is deleted", function(done) {
-    // we only run test if icons are enabled
-    finishTestIfIconsAreNotEnabled(done, function(){
-      var inner$ = helper.padInner$;
-      var outer$ = helper.padOuter$;
-
-      deleteComment(function() {
-        // check icon is not visible
-        var $commentIcons = outer$("#commentIcons .comment-icon:visible");
-        expect($commentIcons.length).to.be(0);
-
-        done();
       });
     });
   });
-
-  it("updates comment icon height when commented text is moved to another line", function(done) {
+  // TODO: Needs fixing
+  xit('does not show comment icon when comment is deleted', async function() {
     // we only run test if icons are enabled
-    finishTestIfIconsAreNotEnabled(done, function(){
+    await finishTestIfIconsAreNotEnabled(async () => {
+      var inner$ = helper.padInner$;
+      var outer$ = helper.padOuter$;
+
+      await new Promise((resolve) => deleteComment(resolve));
+      // check icon is not visible
+      var $commentIcons = outer$("#commentIcons .comment-icon:visible");
+      expect($commentIcons.length).to.be(0);
+    });
+  });
+
+  it('updates comment icon height when commented text is moved to another line', async function() {
+    // we only run test if icons are enabled
+    await finishTestIfIconsAreNotEnabled(async () => {
       var inner$ = helper.padInner$;
       var outer$ = helper.padOuter$;
       var commentId = getCommentId();
@@ -84,31 +78,25 @@ describe("ep_comments_page - Comment icons", function() {
       $firstTextElement.sendkeys('{leftarrow}{enter}{enter}');
 
       // wait until the new lines are split into separated .ace-line's
-      helper.waitFor(function() {
-        return inner$("div").length > 2;
-      })
-      .done(function() {
-        // wait until comment is visible again
-        helper.waitFor(function() {
-          var $commentIcons = outer$("#commentIcons .comment-icon:visible");
-          return $commentIcons.length !== 0;
-        })
-        .done(function() {
-          // check height is the same
-          var $commentIcon = outer$("#commentIcons #icon-"+commentId);
-          var $commentedText = inner$("."+commentId);
-          var expectedTop = $commentedText.offset().top + 5; // all icons are +5px down to adjust position
-          expect($commentIcon.offset().top).to.be(expectedTop);
+      await helper.waitForPromise(() => inner$('div').length > 2);
 
-          done();
-        });
+      // wait until comment is visible again
+      await helper.waitForPromise(() => {
+        var $commentIcons = outer$("#commentIcons .comment-icon:visible");
+        return $commentIcons.length !== 0;
       });
+
+      // check height is the same
+      var $commentIcon = outer$("#commentIcons #icon-"+commentId);
+      var $commentedText = inner$("."+commentId);
+      var expectedTop = $commentedText.offset().top + 5; // all icons are +5px down to adjust position
+      expect($commentIcon.offset().top).to.be(expectedTop);
     });
   });
 
-  it("shows comment when user clicks on comment icon", function(done) {
+  it('shows comment when user clicks on comment icon', async function() {
     // we only run test if icons are enabled
-    finishTestIfIconsAreNotEnabled(done, function(){
+    await finishTestIfIconsAreNotEnabled(async () => {
       var outer$ = helper.padOuter$;
       var commentId = getCommentId();
 
@@ -119,14 +107,12 @@ describe("ep_comments_page - Comment icons", function() {
       // check sidebar comment is visible
       var $openedSidebarComments = outer$("#comments .sidebar-comment:visible");
       expect($openedSidebarComments.length).to.be(1);
-
-      done();
     });
   });
 
-  it("hides comment when user clicks on comment icon twice", function(done) {
+  it('hides comment when user clicks on comment icon twice', async function() {
     // we only run test if icons are enabled
-    finishTestIfIconsAreNotEnabled(done, function(){
+    await finishTestIfIconsAreNotEnabled(async () => {
       var outer$ = helper.padOuter$;
       var commentId = getCommentId();
 
@@ -138,14 +124,12 @@ describe("ep_comments_page - Comment icons", function() {
       // check sidebar comment is not visible
       var $openedSidebarComments = outer$("#comments .sidebar-comment:visible");
       expect($openedSidebarComments.length).to.be(0);
-
-      done();
     });
   });
 
-  it("hides comment when user clicks outside of comment box", function(done) {
+  it('hides comment when user clicks outside of comment box', async function() {
     // we only run test if icons are enabled
-    finishTestIfIconsAreNotEnabled(done, function(){
+    await finishTestIfIconsAreNotEnabled(async () => {
       var outer$ = helper.padOuter$;
       var commentId = getCommentId();
 
@@ -159,14 +143,12 @@ describe("ep_comments_page - Comment icons", function() {
       // check sidebar comment is not visible
       var $openedSidebarComments = outer$("#comments .sidebar-comment:visible");
       expect($openedSidebarComments.length).to.be(0);
-
-      done();
     });
   });
 
-  it("hides first comment and shows second comment when user clicks on one icon then on another icon", function(done) {
+  it('hides first comment and shows second comment when user clicks on one icon then on another icon', async function() {
     // we only run test if icons are enabled
-    finishTestIfIconsAreNotEnabled(done, function(){
+    await finishTestIfIconsAreNotEnabled(async () => {
       var inner$ = helper.padInner$;
       var outer$ = helper.padOuter$;
 
@@ -175,29 +157,23 @@ describe("ep_comments_page - Comment icons", function() {
       $lastTextElement.sendkeys('Second line{enter}');
 
       // wait until the new line is split into a separated .ace-line
-      helper.waitFor(function() {
-        return inner$("div").length > 2;
-      })
-      .done(function() {
-        // ... then add a comment to second line
-        var $secondLine = inner$("div").eq(1);
-        $secondLine.sendkeys('{selectall}');
-        addComment("Second Comment", function() {
-          // click on the icon of first comment...
-          var $firstCommentIcon = outer$("#commentIcons #icon-"+getCommentId(0)).first();
-          $firstCommentIcon.click();
-          // ... then click on the icon of last comment
-          var $secondCommentIcon = outer$("#commentIcons #icon-"+getCommentId(1)).first();
-          $secondCommentIcon.click();
+      await helper.waitForPromise(() => inner$('div').length > 2);
 
-          // check modal is visible
-          var $commentText = outer$("#comments .sidebar-comment:visible .comment-text").text();
-          expect($commentText).to.be("Second Comment");
+      // ... then add a comment to second line
+      var $secondLine = inner$("div").eq(1);
+      $secondLine.sendkeys('{selectall}');
+      await new Promise((resolve) => addComment('Second Comment', resolve));
 
-          done();
+      // click on the icon of first comment...
+      var $firstCommentIcon = outer$("#commentIcons #icon-"+getCommentId(0)).first();
+      $firstCommentIcon.click();
+      // ... then click on the icon of last comment
+      var $secondCommentIcon = outer$("#commentIcons #icon-"+getCommentId(1)).first();
+      $secondCommentIcon.click();
 
-        });
-      });
+      // check modal is visible
+      var $commentText = outer$("#comments .sidebar-comment:visible .comment-text").text();
+      expect($commentText).to.be("Second Comment");
     });
   });
 
@@ -287,11 +263,10 @@ describe("ep_comments_page - Comment icons", function() {
     });
   }
 
-  var finishTestIfIconsAreNotEnabled = function(done, theTest) {
+  const finishTestIfIconsAreNotEnabled = async (theTest) => {
     // #commentIcons will only be inserted if icons are enabled
-    if (helper.padOuter$("#commentIcons").length === 0) done();
-    else theTest(done);
-  }
+    if (helper.padOuter$('#commentIcons').length !== 0) await theTest();
+  };
 
   const chooseToShowComments = (shouldShowComments) => {
     var chrome$ = helper.padChrome$;


### PR DESCRIPTION
**Note: This PR depends on https://github.com/ether/etherpad-lite/pull/4414**.

The `getCommentId()` function uses `helper.waitFor()`, which is asynchronous. Therefore, `getCommentId()` cannot be used synchronously. Convert it to an `async` function and await the resolution wherever it is called.

Also fix the nullish check (`!= null` instead of `!== null`).

I don't understand how any of the tests that used this function ever worked, because it used to always return `undefined` even though all callers expect a comment ID. This makes me concerned that the tests aren't actually testing anything meaningful.

**Please do not squash merge** because there are also some intentionally separate cleanup commits:

* Make unnecessarily asynchronous functions synchronous
* Asyncify `finishTestIfIconsAreNotEnabled`
* Asyncify `addComment`
* Asyncify `deleteComment`
* Asyncify `createComment`
* Asyncify the `after` function