### PR TITLE
tests: timeFormat.js cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,20 +21,20 @@ env:
 
 jobs:
   include:
-     - name: "Lint test package-lock"
-       install:
+    - name: "Lint test package-lock"
+      install:
         - "npm install lockfile-lint"
-       script:
+      script:
         - npx lockfile-lint --path package-lock.json --validate-https --allowed-hosts npm
-     - name: "Run the Backend tests"
-       before_script:
+    - name: "Run the Backend tests"
+      before_script:
         - "tests/frontend/travis/sauce_tunnel.sh"
-       before_install:
+      before_install:
         - sudo add-apt-repository -y ppa:libreoffice/ppa
         - sudo apt-get update
         - sudo apt-get -y install libreoffice
         - sudo apt-get -y install libreoffice-pdfimport
-       install:
+      install:
         - "npm install"
         - "mkdir ep_comments_page"
         - "mv !(ep_comments_page) ep_comments_page"
@@ -45,12 +45,12 @@ jobs:
         - "bin/installDeps.sh"
         - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"
         - "cd src && npm install && cd -"
-       script:
+      script:
         - "tests/frontend/travis/runnerBackend.sh"
-     - name: "Test the Frontend"
-       before_script:
+    - name: "Test the Frontend"
+      before_script:
         - "tests/frontend/travis/sauce_tunnel.sh"
-       install:
+      install:
         - "npm install"
         - "mkdir ep_comments_page"
         - "mv !(ep_comments_page) ep_comments_page"
@@ -60,7 +60,7 @@ jobs:
         - "mv ../ep_comments_page node_modules"
         - "bin/installDeps.sh"
         - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"
-       script:
+      script:
         - "tests/frontend/travis/runner.sh"
 
 notifications:

--- a/static/tests/frontend/specs/timeFormat.js
+++ b/static/tests/frontend/specs/timeFormat.js
@@ -1,3 +1,5 @@
+/* global _, after, before, describe, expect, helper, it */
+
 var moment;
 
 describe("ep_comments_page - Time Formatting", function() {

--- a/static/tests/frontend/specs/timeFormat.js
+++ b/static/tests/frontend/specs/timeFormat.js
@@ -2,9 +2,9 @@
 
 var moment;
 
-describe("ep_comments_page - Time Formatting", function() {
+describe('ep_comments_page - Time Formatting', function() {
   _.each({'en': 'English', 'af': 'a language not localized yet'}, function(description, lang) {
-    describe("in " + description, function(){
+    describe('in ' + description, function() {
       before(function(cb) {
         loadMoment(function() {
           changeLanguageTo(lang, cb);
@@ -17,139 +17,139 @@ describe("ep_comments_page - Time Formatting", function() {
         changeLanguageTo('en', cb);
       });
 
-      it("returns '12 seconds ago' when time is 12 seconds in the past", function(done) {
+      it('returns "12 seconds ago" when time is 12 seconds in the past', function(done) {
         expect(moment(secondsInThePast(12)).fromNow()).to.be('12 seconds ago');
         done();
       });
 
-      it("returns 'in 12 seconds' when time is 12 seconds in the future", function(done) {
+      it('returns "in 12 seconds" when time is 12 seconds in the future', function(done) {
         expect(moment(secondsInTheFuture(12)).fromNow()).to.be('in 12 seconds');
         done();
       });
 
-      it("returns 'a minute ago' when time is 75 seconds in the past", function(done) {
+      it('returns "a minute ago" when time is 75 seconds in the past', function(done) {
         expect(moment(secondsInThePast(75)).fromNow()).to.be('a minute ago');
         done();
       });
 
-      it("returns 'in a minute' when time is 75 seconds in the future", function(done) {
+      it('returns "in a minute" when time is 75 seconds in the future', function(done) {
         expect(moment(secondsInTheFuture(75)).fromNow()).to.be('in a minute');
         done();
       });
 
-      it("returns '17 minutes ago' when time is some seconds before 17 minutes in the past", function(done) {
+      it('returns "17 minutes ago" when time is some seconds before 17 minutes in the past', function(done) {
         expect(moment(secondsInThePast(minutes(17) + 2)).fromNow()).to.be('17 minutes ago');
         done();
       });
 
-      it("returns 'in 17 minutes' when time is some seconds after 17 minutes in the future", function(done) {
+      it('returns "in 17 minutes" when time is some seconds after 17 minutes in the future', function(done) {
         expect(moment(secondsInTheFuture(minutes(17) + 2)).fromNow()).to.be('in 17 minutes');
         done();
       });
 
-      it("returns 'an hour ago' when time is some seconds before 1 hour in the past", function(done) {
+      it('returns "an hour ago" when time is some seconds before 1 hour in the past', function(done) {
         expect(moment(secondsInThePast(hours(1) + 3)).fromNow()).to.be('an hour ago');
         done();
       });
 
-      it("returns 'in an hour' when time is some seconds after 1 hour in the future", function(done) {
+      it('returns "in an hour" when time is some seconds after 1 hour in the future', function(done) {
         expect(moment(secondsInTheFuture(hours(1) + 3)).fromNow()).to.be('in an hour');
         done();
       });
 
-      it("returns '2 hours ago' when time is some seconds before 2 hours in the past", function(done) {
+      it('returns "2 hours ago" when time is some seconds before 2 hours in the past', function(done) {
         expect(moment(secondsInThePast(hours(2) + 4)).fromNow()).to.be('2 hours ago');
         done();
       });
 
-      it("returns 'in 2 hours' when time is some seconds after 2 hours in the future", function(done) {
+      it('returns "in 2 hours" when time is some seconds after 2 hours in the future', function(done) {
         expect(moment(secondsInTheFuture(hours(2) + 4)).fromNow()).to.be('in 2 hours');
         done();
       });
 
-      it("returns 'a day ago' when time is some seconds before 24 hours in the past", function(done) {
+      it('returns "a day ago" when time is some seconds before 24 hours in the past', function(done) {
         expect(moment(secondsInThePast(hours(24) + 5)).fromNow()).to.be('a day ago');
         done();
       });
 
-      it("returns 'in a day' when time is some seconds after 24 hours in the future", function(done) {
+      it('returns "in a day" when time is some seconds after 24 hours in the future', function(done) {
         expect(moment(secondsInTheFuture(hours(24) + 5)).fromNow()).to.be('in a day');
         done();
       });
 
-      it("returns '6 days ago' when time is some seconds before 6 days in the past", function(done) {
+      it('returns "6 days ago" when time is some seconds before 6 days in the past', function(done) {
         expect(moment(secondsInThePast(days(6) + 6)).fromNow()).to.be('6 days ago');
         done();
       });
 
-      it("returns 'in 6 days' when time is some seconds after 6 days in the future", function(done) {
+      it('returns "in 6 days" when time is some seconds after 6 days in the future', function(done) {
         expect(moment(secondsInTheFuture(days(6) + 6)).fromNow()).to.be('in 6 days');
         done();
       });
 
-      it("returns '7 days ago' when time is some seconds before 7 days in the past", function(done) {
+      it('returns "7 days ago" when time is some seconds before 7 days in the past', function(done) {
         expect(moment(secondsInThePast(days(7) + 7)).fromNow()).to.be('7 days ago');
         done();
       });
 
-      it("returns 'in 7 days' when time is some seconds after 7 days in the future", function(done) {
+      it('returns "in 7 days" when time is some seconds after 7 days in the future', function(done) {
         expect(moment(secondsInTheFuture(days(7) + 7)).fromNow()).to.be('in 7 days');
         done();
       });
 
-      it("returns '14 days ago' when time is some seconds before 2 weeks in the past", function(done) {
+      it('returns "14 days ago" when time is some seconds before 2 weeks in the past', function(done) {
         expect(moment(secondsInThePast(weeks(2) + 8)).fromNow()).to.be('14 days ago');
         done();
       });
 
-      it("returns 'in 14 days' when time is some seconds after 2 weeks in the future", function(done) {
+      it('returns "in 14 days" when time is some seconds after 2 weeks in the future', function(done) {
         expect(moment(secondsInTheFuture(weeks(2) + 8)).fromNow()).to.be('in 14 days');
         done();
       });
 
-      it("returns 'a month ago' when time is some seconds before 4 weeks in the past", function(done) {
+      it('returns "a month ago" when time is some seconds before 4 weeks in the past', function(done) {
         expect(moment(secondsInThePast(weeks(4) + 9)).fromNow()).to.be('a month ago');
         done();
       });
 
-      it("returns 'in a month' when time is some seconds after 4 weeks in the future", function(done) {
+      it('returns "in a month" when time is some seconds after 4 weeks in the future', function(done) {
         expect(moment(secondsInTheFuture(weeks(4) + 9)).fromNow()).to.be('in a month');
         done();
       });
 
-      it("returns '8 months ago' when time is some seconds before 9 months in the past", function(done) {
+      it('returns "8 months ago" when time is some seconds before 9 months in the past', function(done) {
         expect(moment(secondsInThePast(months(9) + 10)).fromNow()).to.be('8 months ago');
         done();
       });
 
-      it("returns 'in 8 months' when time is some seconds after 9 months in the future", function(done) {
+      it('returns "in 8 months" when time is some seconds after 9 months in the future', function(done) {
         expect(moment(secondsInTheFuture(months(9) + 10)).fromNow()).to.be('in 8 months');
         done();
       });
 
-      it("returns 'a year ago' when time is some seconds before 12 months in the past", function(done) {
+      it('returns "a year ago" when time is some seconds before 12 months in the past', function(done) {
         expect(moment(secondsInThePast(months(12) + 11)).fromNow()).to.be('a year ago');
         done();
       });
 
-      it("returns 'in a year' when time is some seconds after 12 months in the future", function(done) {
+      it('returns "in a year" when time is some seconds after 12 months in the future', function(done) {
         expect(moment(secondsInTheFuture(months(12) + 11)).fromNow()).to.be('in a year');
         done();
       });
 
-      it("returns '14 years ago' when time is some seconds before 15 years in the past", function(done) {
+      it('returns "14 years ago" when time is some seconds before 15 years in the past', function(done) {
         expect(moment(secondsInThePast(years(15) + 12)).fromNow()).to.be('14 years ago');
         done();
       });
 
-      it("returns ' in 14 years' when time is some seconds after 15 years in the future", function(done) {
+      it('returns " in 14 years" when time is some seconds after 15 years in the future', function(done) {
         expect(moment(secondsInTheFuture(years(15) + 12)).fromNow()).to.be('in 14 years');
         done();
       });
     })
   });
 
-  describe("in Portuguese", function(){
+  describe('in Portuguese', function() {
     before(function(cb) {
       loadMoment(function() {
         changeLanguageTo('pt-br', cb);
@@ -158,132 +158,132 @@ describe("ep_comments_page - Time Formatting", function() {
       this.timeout(60000);
     });
 
-    it("returns 'há 12 segundos' when time is 12 seconds in the past", function(done) {
+    it('returns "há 12 segundos" when time is 12 seconds in the past', function(done) {
       expect(moment(secondsInThePast(12)).fromNow()).to.be('há 12 segundos');
       done();
     });
 
-    it("returns 'em 12 segundos' when time is 12 seconds in the future", function(done) {
+    it('returns "em 12 segundos" when time is 12 seconds in the future', function(done) {
       expect(moment(secondsInTheFuture(12)).fromNow()).to.be('em 12 segundos');
       done();
     });
 
-    it("returns 'há um minuto' when time is 75 seconds in the past", function(done) {
+    it('returns "há um minuto" when time is 75 seconds in the past', function(done) {
       expect(moment(secondsInThePast(75)).fromNow()).to.be('há um minuto');
       done();
     });
 
-    it("returns 'em um minuto' when time is 75 seconds in the future", function(done) {
+    it('returns "em um minuto" when time is 75 seconds in the future', function(done) {
       expect(moment(secondsInTheFuture(75)).fromNow()).to.be('em um minuto');
       done();
     });
 
-    it("returns 'há 17 minutos' when time is some seconds before 17 minutes in the past", function(done) {
+    it('returns "há 17 minutos" when time is some seconds before 17 minutes in the past', function(done) {
       expect(moment(secondsInThePast(minutes(17) + 2)).fromNow()).to.be('há 17 minutos');
       done();
     });
 
-    it("returns 'em 17 minutos' when time is some seconds after 17 minutes in the future", function(done) {
+    it('returns "em 17 minutos" when time is some seconds after 17 minutes in the future', function(done) {
       expect(moment(secondsInTheFuture(minutes(17) + 2)).fromNow()).to.be('em 17 minutos');
       done();
     });
 
-    it("returns 'há uma hora' when time is some seconds before 1 hour in the past", function(done) {
+    it('returns "há uma hora" when time is some seconds before 1 hour in the past', function(done) {
       expect(moment(secondsInThePast(hours(1) + 3)).fromNow()).to.be('há uma hora');
       done();
     });
 
-    it("returns 'em uma hora' when time is some seconds after 1 hour in the future", function(done) {
+    it('returns "em uma hora" when time is some seconds after 1 hour in the future', function(done) {
       expect(moment(secondsInTheFuture(hours(1) + 3)).fromNow()).to.be('em uma hora');
       done();
     });
 
-    it("returns 'há 2 horas' when time is some seconds before 2 hours in the past", function(done) {
+    it('returns "há 2 horas" when time is some seconds before 2 hours in the past', function(done) {
       expect(moment(secondsInThePast(hours(2) + 4)).fromNow()).to.be('há 2 horas');
       done();
     });
 
-    it("returns 'em 2 horas' when time is some seconds after 2 hours in the future", function(done) {
+    it('returns "em 2 horas" when time is some seconds after 2 hours in the future', function(done) {
       expect(moment(secondsInTheFuture(hours(2) + 4)).fromNow()).to.be('em 2 horas');
       done();
     });
 
-    it("returns 'há um dia' when time is some seconds before 24 hours in the past", function(done) {
+    it('returns "há um dia" when time is some seconds before 24 hours in the past', function(done) {
       expect(moment(secondsInThePast(hours(24) + 5)).fromNow()).to.be('há um dia');
       done();
     });
 
-    it("returns 'em um dia' when time is some seconds after 24 hours in the future", function(done) {
+    it('returns "em um dia" when time is some seconds after 24 hours in the future', function(done) {
       expect(moment(secondsInTheFuture(hours(24) + 5)).fromNow()).to.be('em um dia');
       done();
     });
 
-    it("returns 'há 6 dias' when time is some seconds before 6 days in the past", function(done) {
+    it('returns "há 6 dias" when time is some seconds before 6 days in the past', function(done) {
       expect(moment(secondsInThePast(days(6) + 6)).fromNow()).to.be('há 6 dias');
       done();
     });
 
-    it("returns 'em 6 dias' when time is some seconds after 6 days in the future", function(done) {
+    it('returns "em 6 dias" when time is some seconds after 6 days in the future', function(done) {
       expect(moment(secondsInTheFuture(days(6) + 6)).fromNow()).to.be('em 6 dias');
       done();
     });
 
-    it("returns 'há 7 dias' when time is some seconds before 7 days in the past", function(done) {
+    it('returns "há 7 dias" when time is some seconds before 7 days in the past', function(done) {
       expect(moment(secondsInThePast(days(7) + 7)).fromNow()).to.be('há 7 dias');
       done();
     });
 
-    it("returns 'em 7 dias' when time is some seconds after 7 days in the future", function(done) {
+    it('returns "em 7 dias" when time is some seconds after 7 days in the future', function(done) {
       expect(moment(secondsInTheFuture(days(7) + 7)).fromNow()).to.be('em 7 dias');
       done();
     });
 
-    it("returns 'há 14 dias' when time is some seconds before 2 weeks in the past", function(done) {
+    it('returns "há 14 dias" when time is some seconds before 2 weeks in the past', function(done) {
       expect(moment(secondsInThePast(weeks(2) + 8)).fromNow()).to.be('há 14 dias');
       done();
     });
 
-    it("returns 'em 14 dias' when time is some seconds after 2 weeks in the future", function(done) {
+    it('returns "em 14 dias" when time is some seconds after 2 weeks in the future', function(done) {
       expect(moment(secondsInTheFuture(weeks(2) + 8)).fromNow()).to.be('em 14 dias');
       done();
     });
 
-    it("returns 'há um mês' when time is some seconds before 4 weeks in the past", function(done) {
+    it('returns "há um mês" when time is some seconds before 4 weeks in the past', function(done) {
       expect(moment(secondsInThePast(weeks(4) + 9)).fromNow()).to.be('há um mês');
       done();
     });
 
-    it("returns 'em um mês' when time is some seconds after 4 weeks in the future", function(done) {
+    it('returns "em um mês" when time is some seconds after 4 weeks in the future', function(done) {
       expect(moment(secondsInTheFuture(weeks(4) + 9)).fromNow()).to.be('em um mês');
       done();
     });
 
-    it("returns 'há 8 meses' when time is some seconds before 9 months in the past", function(done) {
+    it('returns "há 8 meses" when time is some seconds before 9 months in the past', function(done) {
       expect(moment(secondsInThePast(months(9) + 10)).fromNow()).to.be('há 8 meses');
       done();
     });
 
-    it("returns 'em 8 meses' when time is some seconds after 9 months in the future", function(done) {
+    it('returns "em 8 meses" when time is some seconds after 9 months in the future', function(done) {
       expect(moment(secondsInTheFuture(months(9) + 10)).fromNow()).to.be('em 8 meses');
       done();
     });
 
-    it("returns 'há um ano' when time is some seconds before 12 months in the past", function(done) {
+    it('returns "há um ano" when time is some seconds before 12 months in the past', function(done) {
       expect(moment(secondsInThePast(months(12) + 11)).fromNow()).to.be('há um ano');
       done();
     });
 
-    it("returns 'em um ano' when time is some seconds after 12 months in the future", function(done) {
+    it('returns "em um ano" when time is some seconds after 12 months in the future', function(done) {
       expect(moment(secondsInTheFuture(months(12) + 11)).fromNow()).to.be('em um ano');
       done();
     });
 
-    it("returns 'há 14 anos' when time is some seconds before 15 years in the past", function(done) {
+    it('returns "há 14 anos" when time is some seconds before 15 years in the past', function(done) {
       expect(moment(secondsInThePast(years(15) + 12)).fromNow()).to.be('há 14 anos');
       done();
     });
 
-    it("returns 'em 14 anos' when time is some seconds after 15 years in the future", function(done) {
+    it('returns "em 14 anos" when time is some seconds after 15 years in the future', function(done) {
       expect(moment(secondsInTheFuture(years(15) + 12)).fromNow()).to.be('em 14 anos');
       done();
     });
@@ -348,11 +348,11 @@ describe("ep_comments_page - Time Formatting", function() {
     var chrome$ = helper.padChrome$;
 
     //click on the settings button to make settings visible
-    var $settingsButton = chrome$(".buttonicon-settings");
+    var $settingsButton = chrome$('.buttonicon-settings');
     $settingsButton.click();
 
     //select the language
-    var $language = chrome$("#languagemenu");
+    var $language = chrome$('#languagemenu');
     $language.val(lang);
     $language.change();
 
@@ -360,7 +360,7 @@ describe("ep_comments_page - Time Formatting", function() {
     $settingsButton.click();
 
     helper.waitFor(function() {
-      return chrome$(".buttonicon-bold").parent()[0]["title"] == boldTitles[lang];
+      return chrome$('.buttonicon-bold').parent()[0]['title'] == boldTitles[lang];
      })
     .done(callback);
   }

--- a/static/tests/frontend/specs/timeFormat.js
+++ b/static/tests/frontend/specs/timeFormat.js
@@ -259,17 +259,17 @@ describe('ep_comments_page - Time Formatting', function() {
 
   const changeLanguageTo = async (lang) => {
     const boldTitles = {
-      'en' : 'Bold (Ctrl+B)',
-      'pt-br' : 'Negrito (Ctrl-B)',
-      'af' : 'Vet (Ctrl-B)'
+      'en': 'Bold (Ctrl+B)',
+      'pt-br': 'Negrito (Ctrl-B)',
+      'af': 'Vet (Ctrl-B)',
     };
     const chrome$ = helper.padChrome$;
 
-    //click on the settings button to make settings visible
+    // click on the settings button to make settings visible
     const $settingsButton = chrome$('.buttonicon-settings');
     $settingsButton.click();
 
-    //select the language
+    // select the language
     const $language = chrome$('#languagemenu');
     $language.val(lang);
     $language.change();

--- a/static/tests/frontend/specs/timeFormat.js
+++ b/static/tests/frontend/specs/timeFormat.js
@@ -146,7 +146,7 @@ describe('ep_comments_page - Time Formatting', function() {
         expect(moment(secondsInTheFuture(years(15) + 12)).fromNow()).to.be('in 14 years');
         done();
       });
-    })
+    });
   });
 
   describe('in Portuguese', function() {
@@ -293,35 +293,35 @@ describe('ep_comments_page - Time Formatting', function() {
 
   var secondsInThePast = function(seconds) {
     return Date.now() - seconds * 1000;
-  }
+  };
 
   var secondsInTheFuture = function(seconds) {
     return Date.now() + seconds * 1000;
-  }
+  };
 
   var minutes = function(count) {
     return 60 * count;
-  }
+  };
 
   var hours = function(count) {
     return 60 * minutes(count);
-  }
+  };
 
   var days = function(count) {
     return 24 * hours(count);
-  }
+  };
 
   var weeks = function(count) {
     return 7 * days(count);
-  }
+  };
 
   var months = function(count) {
     return 4 * weeks(count);
-  }
+  };
 
   var years = function(count) {
     return 12 * months(count);
-  }
+  };
 
   var loadMoment = function(done) {
     helper.newPad(function() {
@@ -337,7 +337,7 @@ describe('ep_comments_page - Time Formatting', function() {
         done(exception);
       });
     });
-  }
+  };
 
   var changeLanguageTo = function(lang, callback) {
     var boldTitles = {
@@ -363,5 +363,5 @@ describe('ep_comments_page - Time Formatting', function() {
       return chrome$('.buttonicon-bold').parent()[0]['title'] == boldTitles[lang];
      })
     .done(callback);
-  }
+  };
 });

--- a/static/tests/frontend/specs/timeFormat.js
+++ b/static/tests/frontend/specs/timeFormat.js
@@ -144,29 +144,6 @@ describe("ep_comments_page - Time Formatting", function() {
         expect(moment(secondsInTheFuture(years(15) + 12)).fromNow()).to.be('in 14 years');
         done();
       });
-
-      //momentjs doesn't support century
-/*
-      it("returns 'last century' when time is some seconds before 100 years in the past", function(done) {
-        expect(moment(secondsInThePast(years(100) + 13)).fromNow()).to.be('last century');
-        done();
-      });
-
-      it("returns 'next century' when time is some seconds after 100 years in the future", function(done) {
-        expect(moment(secondsInTheFuture(years(100) + 13)).fromNow()).to.be('next century');
-        done();
-      });
-
-      it("returns '2 centuries ago' when time is some seconds before 2 centuries in the past", function(done) {
-        expect(moment(secondsInThePast(centuries(2) + 14)).fromNow()).to.be('2 centuries ago');
-        done();
-      });
-
-      it("returns '2 centuries from now' when time is some seconds after 2 centuries in the future", function(done) {
-        expect(moment(secondsInTheFuture(centuries(2) + 14)).fromNow()).to.be('2 centuries from now');
-        done();
-      }); */
-
     })
   });
 
@@ -308,27 +285,6 @@ describe("ep_comments_page - Time Formatting", function() {
       expect(moment(secondsInTheFuture(years(15) + 12)).fromNow()).to.be('em 14 anos');
       done();
     });
-/* Moment doesn't support centuries
-    it("returns 'século passado' when time is some seconds before 100 years in the past", function(done) {
-      expect(moment(secondsInThePast(years(100) + 13)).fromNow()).to.be('século passado');
-      done();
-    });
-
-    it("returns 'próximo século' when time is some seconds after 100 years in the future", function(done) {
-      expect(moment(secondsInTheFuture(years(100) + 13)).fromNow()).to.be('próximo século');
-      done();
-    });
-
-    it("returns '2 séculos atrás' when time is some seconds before 2 centuries in the past", function(done) {
-      expect(moment(secondsInThePast(centuries(2) + 14)).fromNow()).to.be('2 séculos atrás');
-      done();
-    });
-
-    it("returns 'daqui a 2 séculos' when time is some seconds after 2 centuries in the future", function(done) {
-      expect(moment(secondsInTheFuture(centuries(2) + 14)).fromNow()).to.be('daqui a 2 séculos');
-      done();
-    });
-*/
   });
 
   /* ********** Helper functions ********** */
@@ -363,10 +319,6 @@ describe("ep_comments_page - Time Formatting", function() {
 
   var years = function(count) {
     return 12 * months(count);
-  }
-
-  var centuries = function(count) {
-    return 100 * years(count);
   }
 
   var loadMoment = function(done) {

--- a/static/tests/frontend/specs/timeFormat.js
+++ b/static/tests/frontend/specs/timeFormat.js
@@ -1,6 +1,6 @@
 /* global _, after, before, describe, expect, helper, it */
 
-var moment;
+let moment;
 
 describe('ep_comments_page - Time Formatting', function() {
   _.each({'en': 'English', 'af': 'a language not localized yet'}, function(description, lang) {
@@ -291,41 +291,41 @@ describe('ep_comments_page - Time Formatting', function() {
 
   /* ********** Helper functions ********** */
 
-  var secondsInThePast = function(seconds) {
+  const secondsInThePast = function(seconds) {
     return Date.now() - seconds * 1000;
   };
 
-  var secondsInTheFuture = function(seconds) {
+  const secondsInTheFuture = function(seconds) {
     return Date.now() + seconds * 1000;
   };
 
-  var minutes = function(count) {
+  const minutes = function(count) {
     return 60 * count;
   };
 
-  var hours = function(count) {
+  const hours = function(count) {
     return 60 * minutes(count);
   };
 
-  var days = function(count) {
+  const days = function(count) {
     return 24 * hours(count);
   };
 
-  var weeks = function(count) {
+  const weeks = function(count) {
     return 7 * days(count);
   };
 
-  var months = function(count) {
+  const months = function(count) {
     return 4 * weeks(count);
   };
 
-  var years = function(count) {
+  const years = function(count) {
     return 12 * months(count);
   };
 
-  var loadMoment = function(done) {
+  const loadMoment = function(done) {
     helper.newPad(function() {
-      var chrome$ = helper.padChrome$;
+      const chrome$ = helper.padChrome$;
       chrome$.getScript('/static/plugins/ep_comments_page/static/js/moment-with-locales.min.js')
       .done(function(code){
         chrome$.window.eval(code);
@@ -339,20 +339,20 @@ describe('ep_comments_page - Time Formatting', function() {
     });
   };
 
-  var changeLanguageTo = function(lang, callback) {
-    var boldTitles = {
+  const changeLanguageTo = function(lang, callback) {
+    const boldTitles = {
       'en' : 'Bold (Ctrl+B)',
       'pt-br' : 'Negrito (Ctrl-B)',
       'af' : 'Vet (Ctrl-B)'
     };
-    var chrome$ = helper.padChrome$;
+    const chrome$ = helper.padChrome$;
 
     //click on the settings button to make settings visible
-    var $settingsButton = chrome$('.buttonicon-settings');
+    const $settingsButton = chrome$('.buttonicon-settings');
     $settingsButton.click();
 
     //select the language
-    var $language = chrome$('#languagemenu');
+    const $language = chrome$('#languagemenu');
     $language.val(lang);
     $language.change();
 

--- a/static/tests/frontend/specs/timeFormat.js
+++ b/static/tests/frontend/specs/timeFormat.js
@@ -291,55 +291,30 @@ describe('ep_comments_page - Time Formatting', function() {
 
   /* ********** Helper functions ********** */
 
-  const secondsInThePast = function(seconds) {
-    return Date.now() - seconds * 1000;
-  };
+  const secondsInThePast = (seconds) => Date.now() - seconds * 1000;
+  const secondsInTheFuture = (seconds) => Date.now() + seconds * 1000;
+  const minutes = (count) => 60 * count;
+  const hours = (count) => 60 * minutes(count);
+  const days = (count) => 24 * hours(count);
+  const weeks = (count) => 7 * days(count);
+  const months = (count) => 4 * weeks(count);
+  const years = (count) => 12 * months(count);
 
-  const secondsInTheFuture = function(seconds) {
-    return Date.now() + seconds * 1000;
-  };
-
-  const minutes = function(count) {
-    return 60 * count;
-  };
-
-  const hours = function(count) {
-    return 60 * minutes(count);
-  };
-
-  const days = function(count) {
-    return 24 * hours(count);
-  };
-
-  const weeks = function(count) {
-    return 7 * days(count);
-  };
-
-  const months = function(count) {
-    return 4 * weeks(count);
-  };
-
-  const years = function(count) {
-    return 12 * months(count);
-  };
-
-  const loadMoment = function(done) {
-    helper.newPad(function() {
+  const loadMoment = (done) => {
+    helper.newPad(() => {
       const chrome$ = helper.padChrome$;
       chrome$.getScript('/static/plugins/ep_comments_page/static/js/moment-with-locales.min.js')
-      .done(function(code){
+      .done((code) => {
         chrome$.window.eval(code);
         moment = chrome$.window.moment;
         moment.relativeTimeThreshold('ss', 0);
         done();
       })
-      .fail(function(jqxhr, settings, exception) {
-        done(exception);
-      });
+      .fail((jqxhr, settings, exception) => done(exception));
     });
   };
 
-  const changeLanguageTo = function(lang, callback) {
+  const changeLanguageTo = (lang, callback) => {
     const boldTitles = {
       'en' : 'Bold (Ctrl+B)',
       'pt-br' : 'Negrito (Ctrl-B)',
@@ -359,9 +334,7 @@ describe('ep_comments_page - Time Formatting', function() {
     // hide settings again
     $settingsButton.click();
 
-    helper.waitFor(function() {
-      return chrome$('.buttonicon-bold').parent()[0]['title'] == boldTitles[lang];
-     })
+    helper.waitFor(() => chrome$('.buttonicon-bold').parent()[0]['title'] == boldTitles[lang])
     .done(callback);
   };
 });

--- a/static/tests/frontend/specs/timeFormat.js
+++ b/static/tests/frontend/specs/timeFormat.js
@@ -17,134 +17,108 @@ describe('ep_comments_page - Time Formatting', function() {
         changeLanguageTo('en', cb);
       });
 
-      it('returns "12 seconds ago" when time is 12 seconds in the past', function(done) {
+      it('returns "12 seconds ago" when time is 12 seconds in the past', function() {
         expect(moment(secondsInThePast(12)).fromNow()).to.be('12 seconds ago');
-        done();
       });
 
-      it('returns "in 12 seconds" when time is 12 seconds in the future', function(done) {
+      it('returns "in 12 seconds" when time is 12 seconds in the future', function() {
         expect(moment(secondsInTheFuture(12)).fromNow()).to.be('in 12 seconds');
-        done();
       });
 
-      it('returns "a minute ago" when time is 75 seconds in the past', function(done) {
+      it('returns "a minute ago" when time is 75 seconds in the past', function() {
         expect(moment(secondsInThePast(75)).fromNow()).to.be('a minute ago');
-        done();
       });
 
-      it('returns "in a minute" when time is 75 seconds in the future', function(done) {
+      it('returns "in a minute" when time is 75 seconds in the future', function() {
         expect(moment(secondsInTheFuture(75)).fromNow()).to.be('in a minute');
-        done();
       });
 
-      it('returns "17 minutes ago" when time is some seconds before 17 minutes in the past', function(done) {
+      it('returns "17 minutes ago" when time is some seconds before 17 minutes in the past', function() {
         expect(moment(secondsInThePast(minutes(17) + 2)).fromNow()).to.be('17 minutes ago');
-        done();
       });
 
-      it('returns "in 17 minutes" when time is some seconds after 17 minutes in the future', function(done) {
+      it('returns "in 17 minutes" when time is some seconds after 17 minutes in the future', function() {
         expect(moment(secondsInTheFuture(minutes(17) + 2)).fromNow()).to.be('in 17 minutes');
-        done();
       });
 
-      it('returns "an hour ago" when time is some seconds before 1 hour in the past', function(done) {
+      it('returns "an hour ago" when time is some seconds before 1 hour in the past', function() {
         expect(moment(secondsInThePast(hours(1) + 3)).fromNow()).to.be('an hour ago');
-        done();
       });
 
-      it('returns "in an hour" when time is some seconds after 1 hour in the future', function(done) {
+      it('returns "in an hour" when time is some seconds after 1 hour in the future', function() {
         expect(moment(secondsInTheFuture(hours(1) + 3)).fromNow()).to.be('in an hour');
-        done();
       });
 
-      it('returns "2 hours ago" when time is some seconds before 2 hours in the past', function(done) {
+      it('returns "2 hours ago" when time is some seconds before 2 hours in the past', function() {
         expect(moment(secondsInThePast(hours(2) + 4)).fromNow()).to.be('2 hours ago');
-        done();
       });
 
-      it('returns "in 2 hours" when time is some seconds after 2 hours in the future', function(done) {
+      it('returns "in 2 hours" when time is some seconds after 2 hours in the future', function() {
         expect(moment(secondsInTheFuture(hours(2) + 4)).fromNow()).to.be('in 2 hours');
-        done();
       });
 
-      it('returns "a day ago" when time is some seconds before 24 hours in the past', function(done) {
+      it('returns "a day ago" when time is some seconds before 24 hours in the past', function() {
         expect(moment(secondsInThePast(hours(24) + 5)).fromNow()).to.be('a day ago');
-        done();
       });
 
-      it('returns "in a day" when time is some seconds after 24 hours in the future', function(done) {
+      it('returns "in a day" when time is some seconds after 24 hours in the future', function() {
         expect(moment(secondsInTheFuture(hours(24) + 5)).fromNow()).to.be('in a day');
-        done();
       });
 
-      it('returns "6 days ago" when time is some seconds before 6 days in the past', function(done) {
+      it('returns "6 days ago" when time is some seconds before 6 days in the past', function() {
         expect(moment(secondsInThePast(days(6) + 6)).fromNow()).to.be('6 days ago');
-        done();
       });
 
-      it('returns "in 6 days" when time is some seconds after 6 days in the future', function(done) {
+      it('returns "in 6 days" when time is some seconds after 6 days in the future', function() {
         expect(moment(secondsInTheFuture(days(6) + 6)).fromNow()).to.be('in 6 days');
-        done();
       });
 
-      it('returns "7 days ago" when time is some seconds before 7 days in the past', function(done) {
+      it('returns "7 days ago" when time is some seconds before 7 days in the past', function() {
         expect(moment(secondsInThePast(days(7) + 7)).fromNow()).to.be('7 days ago');
-        done();
       });
 
-      it('returns "in 7 days" when time is some seconds after 7 days in the future', function(done) {
+      it('returns "in 7 days" when time is some seconds after 7 days in the future', function() {
         expect(moment(secondsInTheFuture(days(7) + 7)).fromNow()).to.be('in 7 days');
-        done();
       });
 
-      it('returns "14 days ago" when time is some seconds before 2 weeks in the past', function(done) {
+      it('returns "14 days ago" when time is some seconds before 2 weeks in the past', function() {
         expect(moment(secondsInThePast(weeks(2) + 8)).fromNow()).to.be('14 days ago');
-        done();
       });
 
-      it('returns "in 14 days" when time is some seconds after 2 weeks in the future', function(done) {
+      it('returns "in 14 days" when time is some seconds after 2 weeks in the future', function() {
         expect(moment(secondsInTheFuture(weeks(2) + 8)).fromNow()).to.be('in 14 days');
-        done();
       });
 
-      it('returns "a month ago" when time is some seconds before 4 weeks in the past', function(done) {
+      it('returns "a month ago" when time is some seconds before 4 weeks in the past', function() {
         expect(moment(secondsInThePast(weeks(4) + 9)).fromNow()).to.be('a month ago');
-        done();
       });
 
-      it('returns "in a month" when time is some seconds after 4 weeks in the future', function(done) {
+      it('returns "in a month" when time is some seconds after 4 weeks in the future', function() {
         expect(moment(secondsInTheFuture(weeks(4) + 9)).fromNow()).to.be('in a month');
-        done();
       });
 
-      it('returns "8 months ago" when time is some seconds before 9 months in the past', function(done) {
+      it('returns "8 months ago" when time is some seconds before 9 months in the past', function() {
         expect(moment(secondsInThePast(months(9) + 10)).fromNow()).to.be('8 months ago');
-        done();
       });
 
-      it('returns "in 8 months" when time is some seconds after 9 months in the future', function(done) {
+      it('returns "in 8 months" when time is some seconds after 9 months in the future', function() {
         expect(moment(secondsInTheFuture(months(9) + 10)).fromNow()).to.be('in 8 months');
-        done();
       });
 
-      it('returns "a year ago" when time is some seconds before 12 months in the past', function(done) {
+      it('returns "a year ago" when time is some seconds before 12 months in the past', function() {
         expect(moment(secondsInThePast(months(12) + 11)).fromNow()).to.be('a year ago');
-        done();
       });
 
-      it('returns "in a year" when time is some seconds after 12 months in the future', function(done) {
+      it('returns "in a year" when time is some seconds after 12 months in the future', function() {
         expect(moment(secondsInTheFuture(months(12) + 11)).fromNow()).to.be('in a year');
-        done();
       });
 
-      it('returns "14 years ago" when time is some seconds before 15 years in the past', function(done) {
+      it('returns "14 years ago" when time is some seconds before 15 years in the past', function() {
         expect(moment(secondsInThePast(years(15) + 12)).fromNow()).to.be('14 years ago');
-        done();
       });
 
-      it('returns " in 14 years" when time is some seconds after 15 years in the future', function(done) {
+      it('returns " in 14 years" when time is some seconds after 15 years in the future', function() {
         expect(moment(secondsInTheFuture(years(15) + 12)).fromNow()).to.be('in 14 years');
-        done();
       });
     });
   });
@@ -158,134 +132,108 @@ describe('ep_comments_page - Time Formatting', function() {
       this.timeout(60000);
     });
 
-    it('returns "há 12 segundos" when time is 12 seconds in the past', function(done) {
+    it('returns "há 12 segundos" when time is 12 seconds in the past', function() {
       expect(moment(secondsInThePast(12)).fromNow()).to.be('há 12 segundos');
-      done();
     });
 
-    it('returns "em 12 segundos" when time is 12 seconds in the future', function(done) {
+    it('returns "em 12 segundos" when time is 12 seconds in the future', function() {
       expect(moment(secondsInTheFuture(12)).fromNow()).to.be('em 12 segundos');
-      done();
     });
 
-    it('returns "há um minuto" when time is 75 seconds in the past', function(done) {
+    it('returns "há um minuto" when time is 75 seconds in the past', function() {
       expect(moment(secondsInThePast(75)).fromNow()).to.be('há um minuto');
-      done();
     });
 
-    it('returns "em um minuto" when time is 75 seconds in the future', function(done) {
+    it('returns "em um minuto" when time is 75 seconds in the future', function() {
       expect(moment(secondsInTheFuture(75)).fromNow()).to.be('em um minuto');
-      done();
     });
 
-    it('returns "há 17 minutos" when time is some seconds before 17 minutes in the past', function(done) {
+    it('returns "há 17 minutos" when time is some seconds before 17 minutes in the past', function() {
       expect(moment(secondsInThePast(minutes(17) + 2)).fromNow()).to.be('há 17 minutos');
-      done();
     });
 
-    it('returns "em 17 minutos" when time is some seconds after 17 minutes in the future', function(done) {
+    it('returns "em 17 minutos" when time is some seconds after 17 minutes in the future', function() {
       expect(moment(secondsInTheFuture(minutes(17) + 2)).fromNow()).to.be('em 17 minutos');
-      done();
     });
 
-    it('returns "há uma hora" when time is some seconds before 1 hour in the past', function(done) {
+    it('returns "há uma hora" when time is some seconds before 1 hour in the past', function() {
       expect(moment(secondsInThePast(hours(1) + 3)).fromNow()).to.be('há uma hora');
-      done();
     });
 
-    it('returns "em uma hora" when time is some seconds after 1 hour in the future', function(done) {
+    it('returns "em uma hora" when time is some seconds after 1 hour in the future', function() {
       expect(moment(secondsInTheFuture(hours(1) + 3)).fromNow()).to.be('em uma hora');
-      done();
     });
 
-    it('returns "há 2 horas" when time is some seconds before 2 hours in the past', function(done) {
+    it('returns "há 2 horas" when time is some seconds before 2 hours in the past', function() {
       expect(moment(secondsInThePast(hours(2) + 4)).fromNow()).to.be('há 2 horas');
-      done();
     });
 
-    it('returns "em 2 horas" when time is some seconds after 2 hours in the future', function(done) {
+    it('returns "em 2 horas" when time is some seconds after 2 hours in the future', function() {
       expect(moment(secondsInTheFuture(hours(2) + 4)).fromNow()).to.be('em 2 horas');
-      done();
     });
 
-    it('returns "há um dia" when time is some seconds before 24 hours in the past', function(done) {
+    it('returns "há um dia" when time is some seconds before 24 hours in the past', function() {
       expect(moment(secondsInThePast(hours(24) + 5)).fromNow()).to.be('há um dia');
-      done();
     });
 
-    it('returns "em um dia" when time is some seconds after 24 hours in the future', function(done) {
+    it('returns "em um dia" when time is some seconds after 24 hours in the future', function() {
       expect(moment(secondsInTheFuture(hours(24) + 5)).fromNow()).to.be('em um dia');
-      done();
     });
 
-    it('returns "há 6 dias" when time is some seconds before 6 days in the past', function(done) {
+    it('returns "há 6 dias" when time is some seconds before 6 days in the past', function() {
       expect(moment(secondsInThePast(days(6) + 6)).fromNow()).to.be('há 6 dias');
-      done();
     });
 
-    it('returns "em 6 dias" when time is some seconds after 6 days in the future', function(done) {
+    it('returns "em 6 dias" when time is some seconds after 6 days in the future', function() {
       expect(moment(secondsInTheFuture(days(6) + 6)).fromNow()).to.be('em 6 dias');
-      done();
     });
 
-    it('returns "há 7 dias" when time is some seconds before 7 days in the past', function(done) {
+    it('returns "há 7 dias" when time is some seconds before 7 days in the past', function() {
       expect(moment(secondsInThePast(days(7) + 7)).fromNow()).to.be('há 7 dias');
-      done();
     });
 
-    it('returns "em 7 dias" when time is some seconds after 7 days in the future', function(done) {
+    it('returns "em 7 dias" when time is some seconds after 7 days in the future', function() {
       expect(moment(secondsInTheFuture(days(7) + 7)).fromNow()).to.be('em 7 dias');
-      done();
     });
 
-    it('returns "há 14 dias" when time is some seconds before 2 weeks in the past', function(done) {
+    it('returns "há 14 dias" when time is some seconds before 2 weeks in the past', function() {
       expect(moment(secondsInThePast(weeks(2) + 8)).fromNow()).to.be('há 14 dias');
-      done();
     });
 
-    it('returns "em 14 dias" when time is some seconds after 2 weeks in the future', function(done) {
+    it('returns "em 14 dias" when time is some seconds after 2 weeks in the future', function() {
       expect(moment(secondsInTheFuture(weeks(2) + 8)).fromNow()).to.be('em 14 dias');
-      done();
     });
 
-    it('returns "há um mês" when time is some seconds before 4 weeks in the past', function(done) {
+    it('returns "há um mês" when time is some seconds before 4 weeks in the past', function() {
       expect(moment(secondsInThePast(weeks(4) + 9)).fromNow()).to.be('há um mês');
-      done();
     });
 
-    it('returns "em um mês" when time is some seconds after 4 weeks in the future', function(done) {
+    it('returns "em um mês" when time is some seconds after 4 weeks in the future', function() {
       expect(moment(secondsInTheFuture(weeks(4) + 9)).fromNow()).to.be('em um mês');
-      done();
     });
 
-    it('returns "há 8 meses" when time is some seconds before 9 months in the past', function(done) {
+    it('returns "há 8 meses" when time is some seconds before 9 months in the past', function() {
       expect(moment(secondsInThePast(months(9) + 10)).fromNow()).to.be('há 8 meses');
-      done();
     });
 
-    it('returns "em 8 meses" when time is some seconds after 9 months in the future', function(done) {
+    it('returns "em 8 meses" when time is some seconds after 9 months in the future', function() {
       expect(moment(secondsInTheFuture(months(9) + 10)).fromNow()).to.be('em 8 meses');
-      done();
     });
 
-    it('returns "há um ano" when time is some seconds before 12 months in the past', function(done) {
+    it('returns "há um ano" when time is some seconds before 12 months in the past', function() {
       expect(moment(secondsInThePast(months(12) + 11)).fromNow()).to.be('há um ano');
-      done();
     });
 
-    it('returns "em um ano" when time is some seconds after 12 months in the future', function(done) {
+    it('returns "em um ano" when time is some seconds after 12 months in the future', function() {
       expect(moment(secondsInTheFuture(months(12) + 11)).fromNow()).to.be('em um ano');
-      done();
     });
 
-    it('returns "há 14 anos" when time is some seconds before 15 years in the past', function(done) {
+    it('returns "há 14 anos" when time is some seconds before 15 years in the past', function() {
       expect(moment(secondsInThePast(years(15) + 12)).fromNow()).to.be('há 14 anos');
-      done();
     });
 
-    it('returns "em 14 anos" when time is some seconds after 15 years in the future', function(done) {
+    it('returns "em 14 anos" when time is some seconds after 15 years in the future', function() {
       expect(moment(secondsInTheFuture(years(15) + 12)).fromNow()).to.be('em 14 anos');
-      done();
     });
   });
 

--- a/static/tests/frontend/specs/timeFormat.js
+++ b/static/tests/frontend/specs/timeFormat.js
@@ -1,9 +1,10 @@
-/* global _, after, before, describe, expect, helper, it */
+/* global after, before, describe, expect, helper, it */
 
 let moment;
 
 describe('ep_comments_page - Time Formatting', function() {
-  _.each({'en': 'English', 'af': 'a language not localized yet'}, function(description, lang) {
+  for (const [lang, description] of
+       Object.entries({'en': 'English', 'af': 'a language not localized yet'})) {
     describe('in ' + description, function() {
       before(async function() {
         this.timeout(60000);
@@ -120,7 +121,7 @@ describe('ep_comments_page - Time Formatting', function() {
         expect(moment(secondsInTheFuture(years(15) + 12)).fromNow()).to.be('in 14 years');
       });
     });
-  });
+  }
 
   describe('in Portuguese', function() {
     before(async function() {


### PR DESCRIPTION
Multiple commits that clean up the tests in `timeFormat.js`:

* .travis.yml: Fix indentation
* tests: Delete commented-out and dead code
* tests: Add ESLint global comment
* tests: Change double quotes to single quotes
* tests: Add missing semicolons
* tests: Use `const`, `let` instead of `var`
* tests: Convert to arrow functions
* tests: Delete unnecessary done callback
* tests: Asyncify
* tests: Avoid underscore.js
* tests: Whitespace fixes
