### PR TITLE
exportHTML.js cleanups

### DIFF
--- a/exportHTML.js
+++ b/exportHTML.js
@@ -26,10 +26,13 @@ exports.getLineHTMLForExport = async (hookName, context) => {
     const commentId = span.data('comment');
     if (!commentId) return; // not a comment.  please optimize me in selector
     if (!comments[commentId]) return; // if this comment has been deleted..
-    span.append(`<sup><a href="#${commentId}">*</a></sup>`);
+    span.append(
+        $('<sup>').append(
+            $('<a>').attr('href', `#${commentId}`).text('*')));
     // Replace data-comment="foo" with class="comment foo".
-    context.lineContent = context.lineContent.replace(
-        /data-comment=["|'](c-[0-9a-zA-Z]+)["|']/gi, 'class="comment $1"');
+    if (/^c-[0-9a-zA-Z]+$/.test(commentId)) {
+      span.removeAttr('data-comment').addClass('comment').addClass(commentId);
+    }
   });
   context.lineContent = content.html();
 };

--- a/exportHTML.js
+++ b/exportHTML.js
@@ -16,7 +16,7 @@ const findAllCommentUsedOn = (pad) => {
 
 exports.getLineHTMLForExport = async (hookName, context) => {
   // I'm not sure how optimal this is - it will do a database lookup for each line..
-  const comments = await commentManager.getComments(context.padId);
+  const {comments} = await commentManager.getComments(context.padId);
 
   const $ = cheerio.load(context.lineContent); // gives us a jquery selector for the html! :)
 
@@ -24,7 +24,7 @@ exports.getLineHTMLForExport = async (hookName, context) => {
   $('span').each(function () {
     const commentId = $(this).data('comment');
     if (!commentId) return; // not a comment.  please optimize me in selector
-    if (!comments.comments[commentId]) return; // if this comment has been deleted..
+    if (!comments[commentId]) return; // if this comment has been deleted..
     $(this).append(`<sup><a href='#${commentId}'>*</a></sup>`);
     context.lineContent = $.html();
 
@@ -35,9 +35,8 @@ exports.getLineHTMLForExport = async (hookName, context) => {
 };
 
 exports.exportHTMLAdditionalContent = async (hookName, {padId}) => {
-  let comments = await commentManager.getComments(padId);
-  if (!comments.comments) return;
-  comments = comments.comments;
+  const {comments} = await commentManager.getComments(padId);
+  if (!comments) return;
   let html = '<div id=comments>';
 
   for (const [commentId, comment] of Object.entries(comments)) {

--- a/exportHTML.js
+++ b/exportHTML.js
@@ -40,15 +40,15 @@ exports.getLineHTMLForExport = async (hookName, context) => {
 exports.exportHTMLAdditionalContent = async (hookName, {padId}) => {
   const {comments} = await commentManager.getComments(padId);
   if (!comments) return;
-  let html = '<div id=comments>';
-
+  const div = $('<div>').attr('id', 'comments');
   for (const [commentId, comment] of Object.entries(comments)) {
-    // prolly should escape text here?
-    html += `<p role="comment" class="comment" id="${commentId}">* ${comment.text}</p>`;
+    div.append(
+        $('<p>')
+            .attr('role', 'comment')
+            .addClass('comment')
+            .attr('id', commentId)
+            .text(`* ${comment.text}`));
   }
-
-  html += '</div>';
-
   // adds additional HTML to the body, we get this HTML from the database of comments:padId
-  return html;
+  return $.html(div);
 };

--- a/exportHTML.js
+++ b/exportHTML.js
@@ -22,10 +22,11 @@ exports.getLineHTMLForExport = async (hookName, context) => {
   const content = $('<div>').html(context.lineContent);
   // include links for each comment which we will add content later.
   content.find('span').each(function () {
-    const commentId = $(this).data('comment');
+    const span = $(this);
+    const commentId = span.data('comment');
     if (!commentId) return; // not a comment.  please optimize me in selector
     if (!comments[commentId]) return; // if this comment has been deleted..
-    $(this).append(`<sup><a href='#${commentId}'>*</a></sup>`);
+    span.append(`<sup><a href="#${commentId}">*</a></sup>`);
     // Replace data-comment="foo" with class="comment foo".
     context.lineContent = context.lineContent.replace(
         /data-comment=["|'](c-[0-9a-zA-Z]+)["|']/gi, 'class="comment $1"');

--- a/exportHTML.js
+++ b/exportHTML.js
@@ -26,12 +26,11 @@ exports.getLineHTMLForExport = async (hookName, context) => {
     if (!commentId) return; // not a comment.  please optimize me in selector
     if (!comments[commentId]) return; // if this comment has been deleted..
     $(this).append(`<sup><a href='#${commentId}'>*</a></sup>`);
-    context.lineContent = content.html();
-
     // Replace data-comment="foo" with class="comment foo".
     context.lineContent = context.lineContent.replace(
         /data-comment=["|'](c-[0-9a-zA-Z]+)["|']/gi, 'class="comment $1"');
   });
+  context.lineContent = content.html();
 };
 
 exports.exportHTMLAdditionalContent = async (hookName, {padId}) => {

--- a/exportHTML.js
+++ b/exportHTML.js
@@ -3,16 +3,16 @@
 const $ = require('ep_etherpad-lite/node_modules/cheerio');
 const commentManager = require('./commentManager');
 
-// Add the props to be supported in export
-exports.exportHtmlAdditionalTagsWithData =
-  async (hookName, pad) => findAllCommentUsedOn(pad).map((name) => ['comment', name]);
-
 // Iterate over pad attributes to find only the comment ones
 const findAllCommentUsedOn = (pad) => {
   const commentsUsed = [];
   pad.pool.eachAttrib((key, value) => { if (key === 'comment') commentsUsed.push(value); });
   return commentsUsed;
 };
+
+// Add the props to be supported in export
+exports.exportHtmlAdditionalTagsWithData =
+  async (hookName, pad) => findAllCommentUsedOn(pad).map((name) => ['comment', name]);
 
 exports.getLineHTMLForExport = async (hookName, context) => {
   // I'm not sure how optimal this is - it will do a database lookup for each line..


### PR DESCRIPTION
Multiple commits:
* Avoid awkward `comments.comments`
* Load HTML into a throwaway div instead of calling `cheerio.load()`
* Avoid redundant `context.lineContent` assignments
* Avoid evaluating `$(this)` multiple times
* getLineHTMLForExport: Use cheerio for all HTML manipulations
* exportHTMLAdditionalContent: Use cheerio to build HTML
* Move function definition above its use
