### PR TITLE
Improve comment edit/delete error handling and tests

### DIFF
--- a/commentManager.js
+++ b/commentManager.js
@@ -169,7 +169,7 @@ exports.changeAcceptedState = async (padId, commentId, state) => {
 };
 
 exports.changeCommentText = async (padId, commentId, commentText, authorId) => {
-  if (commentText.length <= 0) return true;
+  if (commentText.length <= 0) return 'comment_cannot_be_empty';
 
   // Given a comment we update the comment text
 

--- a/commentManager.js
+++ b/commentManager.js
@@ -15,10 +15,8 @@ exports.getComments = async (padId) => {
 };
 
 exports.deleteComment = async (padId, commentId, authorId) => {
-  let comments = await db.get('comments:' + padId);
-  // the entry doesn't exist so far, let's create it
-  if (comments == null) comments = {};
-  // get the entry
+  const comments = await db.get(`comments:${padId}`);
+  if (comments == null || comments[commentId] == null) return 'no_such_comment';
   if (comments[commentId].author !== authorId) {
     return 'unauth';
   }
@@ -183,6 +181,7 @@ exports.changeCommentText = async (padId, commentId, commentText, authorId) => {
 
   // get the entry
   const comments = await db.get(prefix + padId);
+  if (comments == null || comments[commentId] == null) return 'no_such_comment';
   if (comments[commentId].author !== authorId) {
     return 'unauth';
   }

--- a/commentManager.js
+++ b/commentManager.js
@@ -21,12 +21,12 @@ exports.deleteComment = async (padId, commentId, authorId) => {
   const comments = await db.get(`comments:${padId}`);
   if (comments == null || comments[commentId] == null) {
     logger.debug(`ignoring attempt to delete non-existent comment ${commentId}`);
-    return 'no_such_comment';
+    throw new Error('no_such_comment');
   }
   if (comments[commentId].author !== authorId) {
     logger.debug(`author ${authorId} attempted to delete comment ${commentId} ` +
                  `belonging to author ${comments[commentId].author}`);
-    return 'unauth';
+    throw new Error('unauth');
   }
   delete comments[commentId];
   await db.set('comments:' + padId, comments);
@@ -179,7 +179,7 @@ exports.changeAcceptedState = async (padId, commentId, state) => {
 exports.changeCommentText = async (padId, commentId, commentText, authorId) => {
   if (commentText.length <= 0) {
     logger.debug(`ignoring attempt to change comment ${commentId} to the empty string`);
-    return 'comment_cannot_be_empty';
+    throw new Error('comment_cannot_be_empty');
   }
 
   // Given a comment we update the comment text
@@ -194,18 +194,16 @@ exports.changeCommentText = async (padId, commentId, commentText, authorId) => {
   const comments = await db.get(prefix + padId);
   if (comments == null || comments[commentId] == null) {
     logger.debug(`ignoring attempt to edit non-existent comment ${commentId}`);
-    return 'no_such_comment';
+    throw new Error('no_such_comment');
   }
   if (comments[commentId].author !== authorId) {
     logger.debug(`author ${authorId} attempted to edit comment ${commentId} ` +
                  `belonging to author ${comments[commentId].author}`);
-    return 'unauth';
+    throw new Error('unauth');
   }
   // update the comment text
   comments[commentId].text = commentText;
 
   // save the comment updated back
   await db.set(prefix + padId, comments);
-
-  return null;
 };

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -143,6 +143,7 @@ ep_comments.prototype.init = function(){
             });
           });
         },'deleteCommentedSelection', true);
+        return;
       }
 
       if (err === 'unauth') {
@@ -203,6 +204,7 @@ ep_comments.prototype.init = function(){
         // although the comment or reply was saved on the data base successfully, it needs
         // to update the comment or comment reply variable with the new text saved
         self.setCommentOrReplyNewText(commentId, commentText);
+        return;
       }
 
       if (err === 'unauth') {

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -120,44 +120,45 @@ ep_comments.prototype.init = function(){
 
   // Listen for events to delete a comment
   // All this does is remove the comment attr on the selection
-  this.container.parent().on("click", ".comment-delete", function(){
+  this.container.parent().on('click', '.comment-delete', async function () {
     var commentId = $(this).closest('.comment-container')[0].id;
-    self.socket.emit('deleteComment', {padId: self.padId, commentId: commentId, authorId: clientVars.userId}, function (err){
-      if (!err) {
-        self.deleteComment(commentId);
-        var padOuter = $('iframe[name="ace_outer"]').contents();
-        var padInner = padOuter.find('iframe[name="ace_inner"]');
-        var selector = "."+commentId;
-        var ace = self.ace;
+    try {
+      await new Promise((resolve, reject) => {
+        self.socket.emit('deleteComment', {
+          padId: self.padId,
+          commentId,
+          authorId: clientVars.userId,
+        }, (errMsg) => errMsg ? reject(new Error(errMsg)) : resolve());
+      });
+    } catch (err) {
+      if (err.message !== 'unauth') throw err; // Let the uncaught error handler handle it.
+      $.gritter.add({
+        title: html10n.translations['ep_comments_page.error'] || 'Error',
+        text: html10n.translations['ep_comments_page.error.delete_unauth'] ||
+          'You cannot delete other users comments!',
+        class_name: 'error',
+      });
+      return;
+    }
+    self.deleteComment(commentId);
+    const padOuter = $('iframe[name="ace_outer"]').contents();
+    const padInner = padOuter.find('iframe[name="ace_inner"]');
+    const selector = `.${commentId}`;
+    const ace = self.ace;
 
-        ace.callWithAce(function(aceTop){
-          var repArr = aceTop.ace_getRepFromSelector(selector, padInner);
-          // rep is an array of reps..  I will need to iterate over each to do something meaningful..
-          $.each(repArr, function(index, rep){
-            // I don't think we need this nested call
-            ace.callWithAce(function (ace){
-              ace.ace_performSelectionChange(rep[0],rep[1],true);
-              ace.ace_setAttributeOnSelection('comment', 'comment-deleted');
-              // Note that this is the correct way of doing it, instead of there being
-              // a commentId we now flag it as "comment-deleted"
-            });
-          });
-        },'deleteCommentedSelection', true);
-        return;
-      }
-
-      if (err === 'unauth') {
-        $.gritter.add({title: html10n.translations["ep_comments_page.error"] || "Error", text: html10n.translations["ep_comments_page.error.delete_unauth"] || "You cannot delete other users comments!",  class_name: "error"})
-      } else {
-        $.gritter.add({
-          title: "Error",
-          text: err,
-          sticky: true,
-          class_name: "error"
-        })
-      }
-    });
-
+    ace.callWithAce((aceTop) => {
+      const repArr = aceTop.ace_getRepFromSelector(selector, padInner);
+      // rep is an array of reps.. I will need to iterate over each to do something meaningful..
+      $.each(repArr, (index, rep) => {
+        // I don't think we need this nested call
+        ace.callWithAce((ace) => {
+          ace.ace_performSelectionChange(rep[0], rep[1], true);
+          ace.ace_setAttributeOnSelection('comment', 'comment-deleted');
+          // Note that this is the correct way of doing it, instead of there being
+          // a commentId we now flag it as "comment-deleted"
+        });
+      });
+    }, 'deleteCommentedSelection', true);
   });
 
   // Listen for events to edit a comment
@@ -182,7 +183,7 @@ ep_comments.prototype.init = function(){
   });
 
   // submit the edition on the text and update the comment text
-  this.container.parent().on("click", ".comment-edit-submit", function(e){
+  this.container.parent().on('click', '.comment-edit-submit', async function (e) {
     e.preventDefault();
     e.stopPropagation();
     var $commentBox = $(this).closest('.comment-container');
@@ -195,30 +196,28 @@ ep_comments.prototype.init = function(){
     data.commentText = commentText;
     data.authorId = clientVars.userId;
 
-    self.socket.emit('updateCommentText', data, function (err){
-      if(!err) {
-        $commentForm.remove();
-        $commentBox.removeClass('editing');
-        self.updateCommentBoxText(commentId, commentText);
+    try {
+      await new Promise((resolve, reject) => {
+        self.socket.emit('updateCommentText', data,
+          (errMsg) => errMsg ? reject(new Error(errMsg)) : resolve());
+      });
+    } catch (err) {
+      if (err.message !== 'unauth') throw err; // Let the uncaught error handler handle it.
+      $.gritter.add({
+        title: html10n.translations['ep_comments_page.error'] || 'Error',
+        text: html10n.translations['ep_comments_page.error.edit_unauth'] ||
+          'You cannot edit other users comments!',
+        class_name: 'error',
+      });
+      return;
+    }
+    $commentForm.remove();
+    $commentBox.removeClass('editing');
+    self.updateCommentBoxText(commentId, commentText);
 
-        // although the comment or reply was saved on the data base successfully, it needs
-        // to update the comment or comment reply variable with the new text saved
-        self.setCommentOrReplyNewText(commentId, commentText);
-        return;
-      }
-
-      if (err === 'unauth') {
-        $.gritter.add({title: html10n.translations["ep_comments_page.error"] || "Error", text: html10n.translations["ep_comments_page.error.edit_unauth"] || "You cannot edit other users comments!",  class_name: "error"})
-      } else {
-        $.gritter.add({
-          title: "Error",
-          text: err,
-          sticky: true,
-          class_name: "error"
-        })
-      }
-
-    });
+    // although the comment or reply was saved on the data base successfully, it needs
+    // to update the comment or comment reply variable with the new text saved
+    self.setCommentOrReplyNewText(commentId, commentText);
   });
 
   // hide the edit form and make the comment author and text visible again

--- a/static/tests/frontend/specs/commentDelete.js
+++ b/static/tests/frontend/specs/commentDelete.js
@@ -31,26 +31,21 @@ describe('ep_comments_page - Comment Delete', function(){
   });
 
   context('when user presses the delete button on other users comment', function(){
-    it("should not delete comment", function(done){
+    it('should not delete comment', async function () {
       var outer$ = helper.padOuter$;
-      setTimeout(function () {
-        helper.newPad({}, helperFunctions.padId);
-        helper.waitFor(function () {
-          outer$ = helper.padOuter$;
-          return !!outer$ && outer$('.comment-delete').length;
-        }).done(function () {
-            outer$('.comment-delete').click();
-            helper.waitFor(function () {
-              var chrome$ = helper.padChrome$;
-
-              return chrome$('#gritter-container').find('.error').length > 0;
-            }).done(function () {
-              var inner$ = helper.padInner$;
-              if(inner$('.comment').length === 0) throw new Error("Error deleting comment");
-              done();
-            });
-        });
-      }, 500);
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      helper.newPad({}, helperFunctions.padId);
+      await helper.waitForPromise(() => {
+        outer$ = helper.padOuter$;
+        return !!outer$ && outer$('.comment-delete').length;
+      });
+      outer$('.comment-delete').click();
+      await helper.waitForPromise(() => {
+        const chrome$ = helper.padChrome$;
+        return chrome$('#gritter-container').find('.error').length > 0;
+      });
+      const inner$ = helper.padInner$;
+      if (inner$('.comment').length === 0) throw new Error('Error deleting comment');
     });
   });
 });

--- a/static/tests/frontend/specs/commentDelete.js
+++ b/static/tests/frontend/specs/commentDelete.js
@@ -45,7 +45,7 @@ describe('ep_comments_page - Comment Delete', function(){
         return chrome$('#gritter-container').find('.error').length > 0;
       });
       const inner$ = helper.padInner$;
-      if (inner$('.comment').length === 0) throw new Error('Error deleting comment');
+      if (inner$('.comment').length === 0) throw new Error('Comment should not have been deleted');
     });
   });
 });

--- a/static/tests/frontend/specs/commentDelete.js
+++ b/static/tests/frontend/specs/commentDelete.js
@@ -34,7 +34,7 @@ describe('ep_comments_page - Comment Delete', function(){
     it('should not delete comment', async function () {
       var outer$ = helper.padOuter$;
       await new Promise((resolve) => setTimeout(resolve, 500));
-      helper.newPad({}, helperFunctions.padId);
+      await new Promise((resolve) => helper.newPad(resolve, helperFunctions.padId));
       await helper.waitForPromise(() => {
         outer$ = helper.padOuter$;
         return !!outer$ && outer$('.comment-delete').length;

--- a/static/tests/frontend/specs/commentEdit.js
+++ b/static/tests/frontend/specs/commentEdit.js
@@ -109,36 +109,30 @@ describe('ep_comments_page - Comment Edit', function(){
     context('new user tries editing', function(){
       var updatedText2 = 'this comment was edited again';
 
-      it('should not update the comment text', function (done) {
+      it('should not update the comment text', async function () {
         var outer$ = helper.padOuter$;
-        setTimeout(function () {
-          helper.newPad({}, helperFunctions.padId);
-          helper.waitFor(function () {
-            outer$ = helper.padOuter$;
-            return !!outer$ && outer$('#comments').find('.comment-edit').length;
-          }).done(function () {
-            helperFunctions.clickEditCommentButton();
-            helperFunctions.writeCommentText(updatedText2)
-            helperFunctions.pressSave();
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        helper.newPad({}, helperFunctions.padId);
+        await helper.waitForPromise(() => {
+          outer$ = helper.padOuter$;
+          return !!outer$ && outer$('#comments').find('.comment-edit').length;
+        });
+        helperFunctions.clickEditCommentButton();
+        helperFunctions.writeCommentText(updatedText2);
+        helperFunctions.pressSave();
 
-            helper.waitFor(function () {
-              //Error message is shown
-              var chrome$ = helper.padChrome$;
-              return chrome$('#gritter-container').find('.error').length > 0;
-            }).done(function () {
-              helper.waitFor(function () {
-                outer$ = helper.padOuter$;
-                var commentText = outer$('.comment-text').first().text();
-                return (commentText !== updatedText2);
-              }).done(function(){
-                var commentText = outer$('.comment-text').first().text();
-                expect(commentText).to.not.be(updatedText2);
-                done();
-              });
-            });
-
-          });
-        }, 500);
+        await helper.waitForPromise(() => {
+          // Error message is shown
+          const chrome$ = helper.padChrome$;
+          return chrome$('#gritter-container').find('.error').length > 0;
+        });
+        await helper.waitForPromise(() => {
+          outer$ = helper.padOuter$;
+          const commentText = outer$('.comment-text').first().text();
+          return (commentText !== updatedText2);
+        });
+        const commentText = outer$('.comment-text').first().text();
+        expect(commentText).to.not.be(updatedText2);
       });
     });
   });

--- a/static/tests/frontend/specs/commentEdit.js
+++ b/static/tests/frontend/specs/commentEdit.js
@@ -112,7 +112,7 @@ describe('ep_comments_page - Comment Edit', function(){
       it('should not update the comment text', async function () {
         var outer$ = helper.padOuter$;
         await new Promise((resolve) => setTimeout(resolve, 500));
-        helper.newPad({}, helperFunctions.padId);
+        await new Promise((resolve) => helper.newPad(resolve, helperFunctions.padId));
         await helper.waitForPromise(() => {
           outer$ = helper.padOuter$;
           return !!outer$ && outer$('#comments').find('.comment-edit').length;


### PR DESCRIPTION
Multiple commits:
* tests: Use Promises to avoid the pyramid of doom
* tests: Wait for pad creation
* tests: Improve test failure error message
* Don't invoke gritter if there is no error
* Return `no_such_comment` error if comment does not exist
* Change `true` error to `'comment_cannot_be_empty'`
* Log erroneous attempts to edit/delete a comment
* Use exceptions for comment edit/delete errors
* Redo client-side error handling for comment edit/delete errors
