### PR TITLE
moment.js language switch and test improvements

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -93,7 +93,8 @@ EpComments.prototype.init = function () {
   // When language is changed, we need to reload the comments to make sure
   // all templates are localized
   html10n.bind('localized', () => {
-    moment.locale(html10n.getLanguage());
+    // Fall back to 'en' if moment.js doesn't support the language.
+    moment.locale([html10n.getLanguage(), 'en']);
     this.localizeExistingComments();
   });
 

--- a/static/tests/frontend/specs/timeFormat.js
+++ b/static/tests/frontend/specs/timeFormat.js
@@ -1,9 +1,15 @@
 'use strict';
 
-let moment;
-
 describe('ep_comments_page - Time Formatting', function () {
+  let moment;
   let originalLanguage = null;
+
+  before(async function () {
+    this.timeout(60000);
+    await new Promise((resolve) => helper.newPad(resolve));
+    moment = helper.padChrome$.window.require('ep_comments_page/static/js/moment-with-locales.min');
+    moment.relativeTimeThreshold('ss', 0);
+  });
 
   after(async function () {
     // Restore the language to avoid breaking other tests.
@@ -14,8 +20,6 @@ describe('ep_comments_page - Time Formatting', function () {
     Object.entries({en: 'English', af: 'a language not localized yet'})) {
     describe(`in ${description}`, function () {
       before(async function () {
-        this.timeout(60000);
-        await loadMoment();
         await changeLanguageTo(lang);
       });
 
@@ -127,8 +131,6 @@ describe('ep_comments_page - Time Formatting', function () {
 
   describe('in Portuguese', function () {
     before(async function () {
-      this.timeout(60000);
-      await loadMoment();
       await changeLanguageTo('pt-br');
     });
 
@@ -247,13 +249,6 @@ describe('ep_comments_page - Time Formatting', function () {
   const weeks = (count) => 7 * days(count);
   const months = (count) => 4 * weeks(count);
   const years = (count) => 12 * months(count);
-
-  const loadMoment = async () => {
-    await new Promise((resolve) => helper.newPad(resolve));
-    const chrome$ = helper.padChrome$;
-    moment = chrome$.window.require('ep_comments_page/static/js/moment-with-locales.min');
-    moment.relativeTimeThreshold('ss', 0);
-  };
 
   const changeLanguageTo = async (lang) => {
     if (originalLanguage == null) originalLanguage = helper.padChrome$.window.html10n.getLanguage();

--- a/static/tests/frontend/specs/timeFormat.js
+++ b/static/tests/frontend/specs/timeFormat.js
@@ -128,7 +128,6 @@ describe('ep_comments_page - Time Formatting', function () {
       this.timeout(60000);
       await loadMoment();
       await changeLanguageTo('pt-br');
-      moment.locale('pt-br');
     });
 
     it('returns "há 12 segundos" when time is 12 seconds in the past', async function () {
@@ -255,27 +254,7 @@ describe('ep_comments_page - Time Formatting', function () {
   };
 
   const changeLanguageTo = async (lang) => {
-    const boldTitles = {
-      'en': 'Bold (Ctrl+B)',
-      'pt-br': 'Negrito (Ctrl-B)',
-      'af': 'Vet (Ctrl-B)',
-    };
-    const chrome$ = helper.padChrome$;
-
-    // click on the settings button to make settings visible
-    const $settingsButton = chrome$('.buttonicon-settings');
-    $settingsButton.click();
-
-    // select the language
-    const $language = chrome$('#languagemenu');
-    $language.val(lang);
-    $language.change();
-
-    // hide settings again
-    $settingsButton.click();
-
-    await helper.waitForPromise(
-        () => chrome$('.buttonicon-bold').parent()[0].title === boldTitles[lang]);
+    helper.padChrome$('#languagemenu').val(lang).trigger('change');
     await helper.waitForPromise(() => moment.locale() === lang);
   };
 });

--- a/static/tests/frontend/specs/timeFormat.js
+++ b/static/tests/frontend/specs/timeFormat.js
@@ -3,6 +3,13 @@
 let moment;
 
 describe('ep_comments_page - Time Formatting', function () {
+  let originalLanguage = null;
+
+  after(async function () {
+    // Restore the language to avoid breaking other tests.
+    if (originalLanguage != null) await changeLanguageTo(originalLanguage);
+  });
+
   for (const [lang, description] of
     Object.entries({en: 'English', af: 'a language not localized yet'})) {
     describe(`in ${description}`, function () {
@@ -10,11 +17,6 @@ describe('ep_comments_page - Time Formatting', function () {
         this.timeout(60000);
         await loadMoment();
         await changeLanguageTo(lang);
-      });
-
-      // ensure we go back to English to avoid breaking other tests:
-      after(async function () {
-        await changeLanguageTo('en');
       });
 
       it('returns "12 seconds ago" when time is 12 seconds in the past', async function () {
@@ -254,6 +256,7 @@ describe('ep_comments_page - Time Formatting', function () {
   };
 
   const changeLanguageTo = async (lang) => {
+    if (originalLanguage == null) originalLanguage = helper.padChrome$.window.html10n.getLanguage();
     helper.padChrome$('#languagemenu').val(lang).trigger('change');
     await helper.waitForPromise(() => moment.locale() === lang);
   };

--- a/static/tests/frontend/specs/timeFormat.js
+++ b/static/tests/frontend/specs/timeFormat.js
@@ -250,10 +250,7 @@ describe('ep_comments_page - Time Formatting', function () {
   const loadMoment = async () => {
     await new Promise((resolve) => helper.newPad(resolve));
     const chrome$ = helper.padChrome$;
-    const code = await chrome$.getScript(
-        '/static/plugins/ep_comments_page/static/js/moment-with-locales.min.js');
-    chrome$.window.eval(code);
-    moment = chrome$.window.moment;
+    moment = chrome$.window.require('ep_comments_page/static/js/moment-with-locales.min');
     moment.relativeTimeThreshold('ss', 0);
   };
 
@@ -279,5 +276,6 @@ describe('ep_comments_page - Time Formatting', function () {
 
     await helper.waitForPromise(
         () => chrome$('.buttonicon-bold').parent()[0].title === boldTitles[lang]);
+    await helper.waitForPromise(() => moment.locale() === lang);
   };
 });

--- a/static/tests/frontend/specs/timeFormat.js
+++ b/static/tests/frontend/specs/timeFormat.js
@@ -16,10 +16,17 @@ describe('ep_comments_page - Time Formatting', function () {
     if (originalLanguage != null) await changeLanguageTo(originalLanguage);
   });
 
-  for (const [lang, description] of
-    Object.entries({en: 'English', af: 'a language not localized yet'})) {
+  for (const [lang, description] of Object.entries({
+    en: 'English',
+    // See https://translatewiki.net/wiki/FAQ#Special_private_language_codes_qqq,_qqx.
+    qqq: 'a language that moment.js does not support',
+  })) {
     describe(`in ${description}`, function () {
       before(async function () {
+        // First switch to a supported language that is not 'en' so that we know when the language
+        // change has taken effect. (This is important because using an unsupported language will
+        // cause moment.js to fall back to 'en'.)
+        await changeLanguageTo('pt-br');
         await changeLanguageTo(lang);
       });
 
@@ -252,7 +259,8 @@ describe('ep_comments_page - Time Formatting', function () {
 
   const changeLanguageTo = async (lang) => {
     if (originalLanguage == null) originalLanguage = helper.padChrome$.window.html10n.getLanguage();
+    expect(helper.padChrome$(`#languagemenu [value=${lang}]`).length).to.be(1);
     helper.padChrome$('#languagemenu').val(lang).trigger('change');
-    await helper.waitForPromise(() => moment.locale() === lang);
+    await helper.waitForPromise(() => moment.locale() === (lang === 'qqq' ? 'en' : lang));
   };
 });


### PR DESCRIPTION
Multiple commits:
* tests: Fix loading of moment.js
* tests: Fix language selection logic
* tests: Restore language after all tests
* Fall back to 'en' if moment.js doesn't support the language
* tests: Reuse the same pad for each language test
* tests: Fix language fallback test
